### PR TITLE
🚑fix: disable placeholder=blur due to error rendering

### DIFF
--- a/app/kanto_event/page.tsx
+++ b/app/kanto_event/page.tsx
@@ -135,7 +135,7 @@ export default function KantoEvent(): JSX.Element {
         width={540}
         height={383}
         alt="こどもテックキャラバン-関東イベント"
-        placeholder="blur"
+        // placeholder="blur"
         priority={true}
         className="w-full"
       />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,7 +20,7 @@ export default function Home(): JSX.Element {
           width={540}
           height={106}
           alt="こどもテックキャラバン-関東イベントバナー"
-          placeholder="blur"
+          // placeholder="blur"
           priority={true}
           className="duration-200 ease-out mb-3 w-full"
         />


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Commented out the placeholder='blur' attribute on Next.js Image components to prevent rendering issues