### PR TITLE
🚑fix: remove --turbopack flag from build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "dev-win": "WATCHPACK_POLLING=true next dev --turbopack",
-    "build": "next build --turbopack",
+    "build": "next build",
     "start": "next start",
     "lint": "bun biome check --write",
     "test:app": "bun test test/app",


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Removed unnecessary --turbopack flag from the build script