### PR TITLE
🐳docker: use node24 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN bun test:app
 RUN bun run build
 
-FROM gcr.io/distroless/nodejs22-debian12:nonroot
+FROM gcr.io/distroless/nodejs24-debian12:nonroot
 WORKDIR /app
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 /lambda-adapter /opt/extensions/lambda-adapter
 


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Upgrade base Docker image from Node.js 22 to Node.js 24