### PR TITLE
🆙bump: update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker.io/docker/dockerfile-upstream:1.16.0-rc1-labs
+# syntax=docker.io/docker/dockerfile-upstream:1.16.0-rc2-labs
 # check=error=true
 FROM oven/bun:canary AS builder
 WORKDIR /usr/src/app

--- a/bun.lock
+++ b/bun.lock
@@ -125,25 +125,25 @@
 
     "@line/bot-sdk": ["@line/bot-sdk@9.9.0", "", { "dependencies": { "@types/node": "^22.0.0" }, "optionalDependencies": { "axios": "^1.7.4" } }, "sha512-/jVjH7k2uMWY1O0F/zkwYD3dqDH/pWbawvDtR6DV/scruH86w9zZrMwknZLt1unUWdK+V9eX4UVP/gLAzqUocg=="],
 
-    "@next/env": ["@next/env@15.4.0-canary.39", "", {}, "sha512-7zv5sd5UN8AkbqT6VtyZLJYX0PbNM+uAl9RMRlVSj42pf/n1oWHqC2pojbKlbK/pGCJgHvCtcdAJoMT7j0rSDA=="],
+    "@next/env": ["@next/env@15.4.0-canary.42", "", {}, "sha512-cGcoCMtImyO1L/hiLXw3R6xOrfLnHsYT1kwlV113hJL261u+ghqH49APCGpZeWwxIuGu20Gj3B3xqqHV5BhKoA=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.0-canary.39", "", { "os": "darwin", "cpu": "arm64" }, "sha512-8vXOwUqwrt9I8IMpZyhLLyHBK3fsjrjHFdlTHFz+vwyxPfuCcRAdkpXX9EzXNTJKwAhokX/Grac8+5ewO5kPTQ=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.0-canary.42", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Iz+bpgbHACNSLtvWjrlB6kgCRKZOTj78C6kvLOgviaeoojeN1UZzo5A49yti3JD1EDGwl/GFDFtdy8ZUSuux9Q=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.0-canary.39", "", { "os": "darwin", "cpu": "x64" }, "sha512-kByQBy3w4oFjo1FjL7gzJ8OMINqoDyEgfDmfxFL4lKbMPLNEV7ALnpHD/p1QE5qzk3xU53IbZs2OF3xTyGNuPA=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.0-canary.42", "", { "os": "darwin", "cpu": "x64" }, "sha512-xN+z0KUi6+9CtV9TFiSHdfycPCsvpbeCPbTG211k3PhwX/n7Sbt7sik7xXwG95zf4sVPNNLtY3ZJx/OrTNLogw=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.0-canary.39", "", { "os": "linux", "cpu": "arm64" }, "sha512-iVeaDaQHsh3aYs9ClMq3nl9JgOQLOyfa4cRi4hDgAsklKSA+nWt/kSokm39pd4Xu6uOUiEoaWa6jijO3E2UljQ=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.0-canary.42", "", { "os": "linux", "cpu": "arm64" }, "sha512-aWT4XvuiNkAoXJI0ZUxVWdngwp8Xe7dcLNTo213W8Mw9enXeso499LqoDeHxJ0Jp8YcL29OK/xi0bqY1W0iQnw=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.0-canary.39", "", { "os": "linux", "cpu": "arm64" }, "sha512-KBc61wPqrkXQNypZkXuyMxgNYnetlh8OhipaPG0FC036J2QV7W7PIdPH0d1DpZYNzOEroNSlhgzczNq84NE40A=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.0-canary.42", "", { "os": "linux", "cpu": "arm64" }, "sha512-4eHAwPE5GHvQclYoUcTZPUij+yjfJMyqybBsCfCNW9ICad6JLpCfq2zuXlNOigeeAmB6hDZmaOkJ3dGKjxiC2Q=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.0-canary.39", "", { "os": "linux", "cpu": "x64" }, "sha512-CsfVIrCKAUh0iaeRxT9UJFNRqzAIoXkeP55pUkEjXQEepRbw3rj9EFA2K2EcIUisgZx/+/kmyhzUxraYjwHeow=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.0-canary.42", "", { "os": "linux", "cpu": "x64" }, "sha512-HVZz9AZuUzqDD3oqM2F5v3NrlMeJcRYA4NEEQPqPZ3H3Do0V32OsetiGAKd2h/jKu0Kg4/k5qnu3koYd2WiiOg=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.0-canary.39", "", { "os": "linux", "cpu": "x64" }, "sha512-gERsrEiDNz8rcRu/TeIsy3yG59rGUaCNTUI017FKH51tZxT+EuvxBItL67c2kd+OSbEfNsnv1FpTsJtjzkcNsw=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.0-canary.42", "", { "os": "linux", "cpu": "x64" }, "sha512-bLFSmTq1G3PJ+umMtOvqvgt1UjDZlGN+V7+cpl3z6JLEq73w4qWAG7fE2oW4yrJWj/ycnyaw5If8epWA8vvcig=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.0-canary.39", "", { "os": "win32", "cpu": "arm64" }, "sha512-cId3IczRaYjUwSZ68LBeebzKuhsgdQtHd4x07sfaPZFQdr6oq4nlsvvndgqnqPt1oYTvMeV2gq/60IwEferSdw=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.0-canary.42", "", { "os": "win32", "cpu": "arm64" }, "sha512-JxUO6ITCXEstv2MChBA/EWFFmtnSUevnbaiFzNfMZC3Fcw5Xeg1cC+pyaYwEtAmkaUxDePuPrZWWtVxKDBI7IA=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.39", "", { "os": "win32", "cpu": "x64" }, "sha512-X29nLn+ZThP4kKDLZOHASjj9mWgPz4JZ8zEErSengQC/IxzDTPxtlzxy5Bii/5Z76DjBKRuMOaUhDy3V5RmEzg=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.42", "", { "os": "win32", "cpu": "x64" }, "sha512-uO3Kd/QYywbR10C1koUgXv4rRYmD193o6Xu9f72WZUjkbpfJXPir+hsURaT2oTyG3koxLit74fwP04KB4K80vw=="],
 
-    "@playwright/test": ["@playwright/test@1.53.0-alpha-2025-05-19", "", { "dependencies": { "playwright": "1.53.0-alpha-2025-05-19" }, "bin": { "playwright": "cli.js" } }, "sha512-wHJWnxNjYWThknkCiw805k0dYjQnQqN2FkYE2UBA5GbMLbMei9m2AR9sMvnmR2hUl+9cOYHJsV1nf77cuHFRvw=="],
+    "@playwright/test": ["@playwright/test@1.53.0-alpha-2025-05-20", "", { "dependencies": { "playwright": "1.53.0-alpha-2025-05-20" }, "bin": { "playwright": "cli.js" } }, "sha512-+3FF0zcgXcV2QpQzjV0EPlvWijUpL1ZlsOT9XFN+jO7xGRRorJyr8uiWdyb3eVx1iNHMz8lYtKSGtlD2vyPTOg=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
@@ -201,7 +201,7 @@
 
     "axios": ["axios@1.7.9", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.0", "proxy-from-env": "^1.1.0" } }, "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw=="],
 
-    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-b1267e9-20250515", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-oF67ElUYIDPxNlU427kYdjyRJc1Dascvu+Rj+9du3o8H2q4Npasu4NyBLefI6q52jQPbjmaBixiBElW7y/uZqg=="],
+    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-b1267e9-20250517", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-8G7qBVfJqIsxDfKqPz+Sxko2EjLi1fsrk0kPAOYRHTnKw16KHIAAR36vXBoJhyyGdZwDzKXK934u09Y6PQfJJA=="],
 
     "bun-types": ["bun-types@1.2.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-rRjA1T6n7wto4gxhAO/ErZEtOXyEZEmnIHQfl0Dt1QQSB4QV0iP6BZ9/YB5fZaHFQ2dwHFrmPaRQ9GGMX01k9Q=="],
 
@@ -291,15 +291,15 @@
 
     "nanoid": ["nanoid@3.3.8", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="],
 
-    "next": ["next@15.4.0-canary.39", "", { "dependencies": { "@next/env": "15.4.0-canary.39", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.0-canary.39", "@next/swc-darwin-x64": "15.4.0-canary.39", "@next/swc-linux-arm64-gnu": "15.4.0-canary.39", "@next/swc-linux-arm64-musl": "15.4.0-canary.39", "@next/swc-linux-x64-gnu": "15.4.0-canary.39", "@next/swc-linux-x64-musl": "15.4.0-canary.39", "@next/swc-win32-arm64-msvc": "15.4.0-canary.39", "@next/swc-win32-x64-msvc": "15.4.0-canary.39", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-VegR4/r8zxhtwg+6COas74cC35y0YDU3/pln9SLATaUKR9AJjuCiVAHxqlVbL37JCtto6dgGPChXaFhivDRpmg=="],
+    "next": ["next@15.4.0-canary.42", "", { "dependencies": { "@next/env": "15.4.0-canary.42", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.0-canary.42", "@next/swc-darwin-x64": "15.4.0-canary.42", "@next/swc-linux-arm64-gnu": "15.4.0-canary.42", "@next/swc-linux-arm64-musl": "15.4.0-canary.42", "@next/swc-linux-x64-gnu": "15.4.0-canary.42", "@next/swc-linux-x64-musl": "15.4.0-canary.42", "@next/swc-win32-arm64-msvc": "15.4.0-canary.42", "@next/swc-win32-x64-msvc": "15.4.0-canary.42", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-8yBgZhWd/wZcqmyG4PrVdJT/kmq20Gqbd/1/q7ysrMvnYyjU8ka4cHv0G+/kcDNqlXGQ+jnsZfujN8VsNjDtNQ=="],
 
     "next-view-transitions": ["next-view-transitions@0.3.4", "", { "peerDependencies": { "next": ">=14.0.0", "react": "^18.2.0", "react-dom": "^18.2.0" } }, "sha512-SSiskenQ8JkEFGzPjvFwC5LGGoqgTxM5dxexkeugxvcXFLpWI2ZUh4IsCURD3ovW+8Ue7xXlrtrpy8b7XR7IwQ=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.53.0-alpha-2025-05-19", "", { "dependencies": { "playwright-core": "1.53.0-alpha-2025-05-19" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-/+dCANeYhJ3+YHi2r2Mh0BfoiZGwBWACrhwsBOg36tn/P//EIJh7Aobqkf4KTHc3p2pa72CrouesRxyrIPB+7w=="],
+    "playwright": ["playwright@1.53.0-alpha-2025-05-20", "", { "dependencies": { "playwright-core": "1.53.0-alpha-2025-05-20" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-n/JuTSa/mBn4SHQz5iBvdhE623bGSuneHUCKUXYvc82kcSamkqF33qMoefzeL3QX3EfGdCnuAi+m4/PJMyR0pg=="],
 
-    "playwright-core": ["playwright-core@1.53.0-alpha-2025-05-19", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-boiVUszihQDk4vH152Z0DaoC1GHlrWG2eD5w+1OuSAvF44o5X6gFIUnG3A2L/wKb8AcnVXp30IEPfV6Yy9Nc6w=="],
+    "playwright-core": ["playwright-core@1.53.0-alpha-2025-05-20", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-UjJ0RbB/i0w4wX+c4mOj1U0F6gBHU9MP9bwFzv+9AtHyP8V0zLAbDdPxBHJv5EqLfbSEF/dIoRBonoTBPXyNkA=="],
 
     "postcss": ["postcss@8.5.3", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A=="],
 


### PR DESCRIPTION
## Sourceryによるサマリー

プロジェクト全体の依存関係を更新するために、Dockerfileの構文バージョンを上げ、bun.lockを再生成しました。

機能拡張:
- 更新された依存関係を反映するためにbun.lockを再生成

ビルド:
- Dockerfileの構文ディレクティブをdockerfile-upstream:1.16.0-rc2-labsに更新

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bump dependencies across the project by updating the Dockerfile syntax version and regenerating the bun.lock

Enhancements:
- Regenerate bun.lock to reflect updated dependencies

Build:
- Update Dockerfile syntax directive to dockerfile-upstream:1.16.0-rc2-labs

</details>