### PR TITLE
🆙bump: update dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -125,25 +125,25 @@
 
     "@line/bot-sdk": ["@line/bot-sdk@9.9.0", "", { "dependencies": { "@types/node": "^22.0.0" }, "optionalDependencies": { "axios": "^1.7.4" } }, "sha512-/jVjH7k2uMWY1O0F/zkwYD3dqDH/pWbawvDtR6DV/scruH86w9zZrMwknZLt1unUWdK+V9eX4UVP/gLAzqUocg=="],
 
-    "@next/env": ["@next/env@15.4.0-canary.42", "", {}, "sha512-cGcoCMtImyO1L/hiLXw3R6xOrfLnHsYT1kwlV113hJL261u+ghqH49APCGpZeWwxIuGu20Gj3B3xqqHV5BhKoA=="],
+    "@next/env": ["@next/env@15.4.0-canary.44", "", {}, "sha512-pN6tVejsOESerMmWcqwvAs/CHgLAWA4FxuVBVqGr2PPDb4XbppSlwxDWZEb6BGVJDzHLAwK+6reT2XJaNAnlmA=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.0-canary.42", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Iz+bpgbHACNSLtvWjrlB6kgCRKZOTj78C6kvLOgviaeoojeN1UZzo5A49yti3JD1EDGwl/GFDFtdy8ZUSuux9Q=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.0-canary.44", "", { "os": "darwin", "cpu": "arm64" }, "sha512-cl0F2vvLQ/Zzy7cLeF+mhPWKHprizxEUMnrixQ7y/vGK7sm2Tg4HZPbAAFNwGOxvYLz9UuCtGUdf7wssoynoGA=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.0-canary.42", "", { "os": "darwin", "cpu": "x64" }, "sha512-xN+z0KUi6+9CtV9TFiSHdfycPCsvpbeCPbTG211k3PhwX/n7Sbt7sik7xXwG95zf4sVPNNLtY3ZJx/OrTNLogw=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.0-canary.44", "", { "os": "darwin", "cpu": "x64" }, "sha512-QGoWAtw3TJF7DoR3PlK52T37EicteUBLJhjZFIuDzci0c1ZsgSLoDI9cUBeDxs265zBdJbuAmkCfLHEyT92r2Q=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.0-canary.42", "", { "os": "linux", "cpu": "arm64" }, "sha512-aWT4XvuiNkAoXJI0ZUxVWdngwp8Xe7dcLNTo213W8Mw9enXeso499LqoDeHxJ0Jp8YcL29OK/xi0bqY1W0iQnw=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.0-canary.44", "", { "os": "linux", "cpu": "arm64" }, "sha512-u6As4DXsY422w3HRZ7zMGbrWd928j/qjSMQO971oeYp+G+IqVkLnWfwUcPZvOo+hxvIpiHryj/KCpK1ZiFdgzQ=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.0-canary.42", "", { "os": "linux", "cpu": "arm64" }, "sha512-4eHAwPE5GHvQclYoUcTZPUij+yjfJMyqybBsCfCNW9ICad6JLpCfq2zuXlNOigeeAmB6hDZmaOkJ3dGKjxiC2Q=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.0-canary.44", "", { "os": "linux", "cpu": "arm64" }, "sha512-7DsoUrqB/CQghKT0zn1RBJUNdnoKPV+lS6rb0vQIjdaFQaIi1pjTYJZKpN2I3LGiq1McmwTiRo+dxjRVIyzhAA=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.0-canary.42", "", { "os": "linux", "cpu": "x64" }, "sha512-HVZz9AZuUzqDD3oqM2F5v3NrlMeJcRYA4NEEQPqPZ3H3Do0V32OsetiGAKd2h/jKu0Kg4/k5qnu3koYd2WiiOg=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.0-canary.44", "", { "os": "linux", "cpu": "x64" }, "sha512-C5CJtdtCMJ+7JrSGQjC2gTDTNrRfKNWgEbOKB2om51DICkvp/5T+fe7OoThlKXZgxyKewBy5XxVZkLYPhSg+Hw=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.0-canary.42", "", { "os": "linux", "cpu": "x64" }, "sha512-bLFSmTq1G3PJ+umMtOvqvgt1UjDZlGN+V7+cpl3z6JLEq73w4qWAG7fE2oW4yrJWj/ycnyaw5If8epWA8vvcig=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.0-canary.44", "", { "os": "linux", "cpu": "x64" }, "sha512-QLuFAJwj7HI7y5vM8BaAHkssehbINNq9yWhcMWsP2NOB+VBXmgQrtuIMWBpyboUPIIHu8vxVEpV40AhWFab8Yw=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.0-canary.42", "", { "os": "win32", "cpu": "arm64" }, "sha512-JxUO6ITCXEstv2MChBA/EWFFmtnSUevnbaiFzNfMZC3Fcw5Xeg1cC+pyaYwEtAmkaUxDePuPrZWWtVxKDBI7IA=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.0-canary.44", "", { "os": "win32", "cpu": "arm64" }, "sha512-APvqR/M8ghjsyq4xtPW+lXX9H7BI+hpWg1c3obajtGNHUiH6feF+4Q5ni7dEkbVuUOvR4xzonzYcwtYvYqcDcg=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.42", "", { "os": "win32", "cpu": "x64" }, "sha512-uO3Kd/QYywbR10C1koUgXv4rRYmD193o6Xu9f72WZUjkbpfJXPir+hsURaT2oTyG3koxLit74fwP04KB4K80vw=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.44", "", { "os": "win32", "cpu": "x64" }, "sha512-X0WwFniF+NdGiUHuXfPr76iPMINXwv6zKb/1uYEPe90mNH7QHgbL23+t32OxiF76tjCNsg7Klte7YY5DTiyUBw=="],
 
-    "@playwright/test": ["@playwright/test@1.53.0-alpha-2025-05-20", "", { "dependencies": { "playwright": "1.53.0-alpha-2025-05-20" }, "bin": { "playwright": "cli.js" } }, "sha512-+3FF0zcgXcV2QpQzjV0EPlvWijUpL1ZlsOT9XFN+jO7xGRRorJyr8uiWdyb3eVx1iNHMz8lYtKSGtlD2vyPTOg=="],
+    "@playwright/test": ["@playwright/test@1.53.0-alpha-2025-05-21", "", { "dependencies": { "playwright": "1.53.0-alpha-2025-05-21" }, "bin": { "playwright": "cli.js" } }, "sha512-Op3hh/3tIRnT63Iy6GmD6+vDZRyjVCQTM3mxEN269hjlvMKXZ+XwgXoY8V7vH5WK75xtCXd/kwSMBvP5R8E41A=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
@@ -201,7 +201,7 @@
 
     "axios": ["axios@1.7.9", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.0", "proxy-from-env": "^1.1.0" } }, "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw=="],
 
-    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-b1267e9-20250517", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-8G7qBVfJqIsxDfKqPz+Sxko2EjLi1fsrk0kPAOYRHTnKw16KHIAAR36vXBoJhyyGdZwDzKXK934u09Y6PQfJJA=="],
+    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-9627644-20250520", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-EH/AFGKbD/Xxy63xAe4SUgSvx4goqMz27OcgGlgfn0FxxdaNCV65+1D6csAe0a79XmA+IFzdCy+j+7XQshUhyQ=="],
 
     "bun-types": ["bun-types@1.2.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-rRjA1T6n7wto4gxhAO/ErZEtOXyEZEmnIHQfl0Dt1QQSB4QV0iP6BZ9/YB5fZaHFQ2dwHFrmPaRQ9GGMX01k9Q=="],
 
@@ -291,15 +291,15 @@
 
     "nanoid": ["nanoid@3.3.8", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="],
 
-    "next": ["next@15.4.0-canary.42", "", { "dependencies": { "@next/env": "15.4.0-canary.42", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.0-canary.42", "@next/swc-darwin-x64": "15.4.0-canary.42", "@next/swc-linux-arm64-gnu": "15.4.0-canary.42", "@next/swc-linux-arm64-musl": "15.4.0-canary.42", "@next/swc-linux-x64-gnu": "15.4.0-canary.42", "@next/swc-linux-x64-musl": "15.4.0-canary.42", "@next/swc-win32-arm64-msvc": "15.4.0-canary.42", "@next/swc-win32-x64-msvc": "15.4.0-canary.42", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-8yBgZhWd/wZcqmyG4PrVdJT/kmq20Gqbd/1/q7ysrMvnYyjU8ka4cHv0G+/kcDNqlXGQ+jnsZfujN8VsNjDtNQ=="],
+    "next": ["next@15.4.0-canary.44", "", { "dependencies": { "@next/env": "15.4.0-canary.44", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.0-canary.44", "@next/swc-darwin-x64": "15.4.0-canary.44", "@next/swc-linux-arm64-gnu": "15.4.0-canary.44", "@next/swc-linux-arm64-musl": "15.4.0-canary.44", "@next/swc-linux-x64-gnu": "15.4.0-canary.44", "@next/swc-linux-x64-musl": "15.4.0-canary.44", "@next/swc-win32-arm64-msvc": "15.4.0-canary.44", "@next/swc-win32-x64-msvc": "15.4.0-canary.44", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-wcDqj32eKJv4dIy5CSuqpzSE+5maFsV5bBZoYTMEbs2gnABKzZHYalCt5Sze+AxWF790p/SbIi+4cBSMf4FVow=="],
 
     "next-view-transitions": ["next-view-transitions@0.3.4", "", { "peerDependencies": { "next": ">=14.0.0", "react": "^18.2.0", "react-dom": "^18.2.0" } }, "sha512-SSiskenQ8JkEFGzPjvFwC5LGGoqgTxM5dxexkeugxvcXFLpWI2ZUh4IsCURD3ovW+8Ue7xXlrtrpy8b7XR7IwQ=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.53.0-alpha-2025-05-20", "", { "dependencies": { "playwright-core": "1.53.0-alpha-2025-05-20" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-n/JuTSa/mBn4SHQz5iBvdhE623bGSuneHUCKUXYvc82kcSamkqF33qMoefzeL3QX3EfGdCnuAi+m4/PJMyR0pg=="],
+    "playwright": ["playwright@1.53.0-alpha-2025-05-21", "", { "dependencies": { "playwright-core": "1.53.0-alpha-2025-05-21" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-zplHUa9ALvRygqhSBQbPtebMAnnj3+Xx0B7hiNM7aqW37tPQLfcMHIkl+TvIIjJRmZjqlRcEqykuZQawisN5yQ=="],
 
-    "playwright-core": ["playwright-core@1.53.0-alpha-2025-05-20", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-UjJ0RbB/i0w4wX+c4mOj1U0F6gBHU9MP9bwFzv+9AtHyP8V0zLAbDdPxBHJv5EqLfbSEF/dIoRBonoTBPXyNkA=="],
+    "playwright-core": ["playwright-core@1.53.0-alpha-2025-05-21", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-W087CBxyE0T1OUHAg2/ZpYyBPm1IOisHQPkGFl1vhT8CgZjW7kWdTR6zyHzY9wwlX0OW+kQXYnp3zPddIaH5KA=="],
 
     "postcss": ["postcss@8.5.3", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A=="],
 


### PR DESCRIPTION
## Sourceryによるサマリー

雑務：
- bun.lockを再生成して、依存関係を更新されたバージョンに引き上げます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Regenerate bun.lock to bump dependencies to their updated versions.

</details>