### PR TITLE
chore: use commit hash on unofficial GitHub Actions

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🐣 Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
         with:
           bun-version: canary
 
@@ -33,4 +33,4 @@ jobs:
         run: bun lint && bun biome ci --reporter=github
 
       - name: 💾 Commit
-        uses: autofix-ci/action@v1.3.1
+        uses: autofix-ci/action@2891949f3779a1cafafae1523058501de3d4e944

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: 🐣 Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
         with:
           bun-version: canary
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,20 +68,20 @@ jobs:
           ref: ${{ env.SHA }}
 
       - name: 🐦‍⬛ Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
 
       - name: 🛠️ Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
 
       - name: 🐋 Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PAT }}
 
       - name: 🚢 Login to GitHub Container Registry
         if: fromJSON(env.IS_PUSH)
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -89,7 +89,7 @@ jobs:
 
       - name: ℹ️ Docker Meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804
         with:
           images: |
             name=${{ env.REPOSITORY }}
@@ -105,7 +105,7 @@ jobs:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: ${{ fromJSON(env.IS_PUSH) && 'manifest,index' || 'manifest' }}
 
       - name: 🚀 Build and Push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         id: push
         with:
           annotations: ${{ steps.meta.outputs.annotations }}
@@ -123,14 +123,14 @@ jobs:
 
       - name: 🪪 Attest
         if: fromJSON(env.IS_PUSH)
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd
         with:
           subject-name: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPOSITORY }}
           subject-digest: ${{ steps.push.outputs.digest }}
 
       - name: 🔎 Docker Scout
         if: github.event_name == 'pull_request_target'
-        uses: docker/scout-action@v1
+        uses: docker/scout-action@aceeb83b88f2ae54376891227858dda7af647183
         with:
           command: compare
           image: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -44,13 +44,13 @@ jobs:
       uses: actions/checkout@v4
 
     - name: 🐦‍⬛ Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
 
     - name: 🛠️ Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
 
     - name: 🪪 Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -58,7 +58,7 @@ jobs:
 
     - name: 🌳 Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v2
+      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076
 
     - name: 🔖 Get an old ImageTag
       run: |
@@ -66,7 +66,7 @@ jobs:
         --query 'imageIds[0].imageTag' --output text)" >> $GITHUB_ENV
 
     - name: 🚀 Build and Push
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
       with:
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -45,7 +45,7 @@ jobs:
           SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: 🐣 Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
         with:
           bun-version: canary
 

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: 🐣 Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
         with:
           bun-version: canary
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🐣 Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
         with:
           bun-version: canary
 


### PR DESCRIPTION
## Sourceryによるサマリー

CIワークフローにおいて、再現性のあるビルドを保証するため、すべてのサードパーティ製GitHub Actionsの使用箇所を、バージョンのタグではなく特定のコミットSHAに固定します。

CI:
- docker/setup-qemu-action の参照を、ワークフロー内の特定のコミットハッシュに更新します。
- docker/setup-buildx-action の参照を、ワークフロー内の特定のコミットハッシュに更新します。
- docker/login-action および docker/metadata-action の参照を、ワークフロー内の特定のコミットハッシュに更新します。
- docker/build-push-action, actions/attest-build-provenance, および docker/scout-action の参照を、ワークフロー内の特定のコミットハッシュに更新します。
- aws-actions/configure-aws-credentials および aws-actions/amazon-ecr-login の参照を、ワークフロー内の特定のコミットハッシュに更新します。
- oven-sh/setup-bun および autofix-ci/action の参照を、ワークフロー内の特定のコミットハッシュに更新します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Pin all third-party GitHub Action usages in CI workflows to specific commit SHAs instead of version tags to ensure reproducible builds.

CI:
- Update docker/setup-qemu-action references to specific commit hashes in workflows.
- Update docker/setup-buildx-action references to specific commit hashes in workflows.
- Update docker/login-action and docker/metadata-action references to specific commit hashes in workflows.
- Update docker/build-push-action, actions/attest-build-provenance, and docker/scout-action references to specific commit hashes in workflows.
- Update aws-actions/configure-aws-credentials and aws-actions/amazon-ecr-login references to specific commit hashes in workflows.
- Update oven-sh/setup-bun and autofix-ci/action references to specific commit hashes in workflows.

</details>