### PR TITLE
ci: update commit.yml

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🐣 Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
         with:
           bun-version: canary
 
@@ -33,4 +33,4 @@ jobs:
         run: bun lint && bun biome ci --reporter=github
 
       - name: 💾 Commit
-        uses: autofix-ci/action@v1.3.1
+        uses: autofix-ci/action@2891949f3779a1cafafae1523058501de3d4e944

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -34,4 +34,4 @@ jobs:
 
       - name: 👀 Validate PR commits with commitlint
         if: github.event_name == 'pull_request'
-        run: bunx commitlint --from ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} --to ${{ github.event.pull_request.head.sha }} --verbose
+        run: bunx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: 🐣 Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
         with:
           bun-version: canary
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,20 +68,20 @@ jobs:
           ref: ${{ env.SHA }}
 
       - name: 🐦‍⬛ Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
 
       - name: 🛠️ Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
 
       - name: 🐋 Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PAT }}
 
       - name: 🚢 Login to GitHub Container Registry
         if: fromJSON(env.IS_PUSH)
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -89,7 +89,7 @@ jobs:
 
       - name: ℹ️ Docker Meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804
         with:
           images: |
             name=${{ env.REPOSITORY }}
@@ -105,7 +105,7 @@ jobs:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: ${{ fromJSON(env.IS_PUSH) && 'manifest,index' || 'manifest' }}
 
       - name: 🚀 Build and Push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         id: push
         with:
           annotations: ${{ steps.meta.outputs.annotations }}
@@ -123,14 +123,14 @@ jobs:
 
       - name: 🪪 Attest
         if: fromJSON(env.IS_PUSH)
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd
         with:
           subject-name: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPOSITORY }}
           subject-digest: ${{ steps.push.outputs.digest }}
 
       - name: 🔎 Docker Scout
         if: github.event_name == 'pull_request_target'
-        uses: docker/scout-action@v1
+        uses: docker/scout-action@aceeb83b88f2ae54376891227858dda7af647183
         with:
           command: compare
           image: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -44,13 +44,13 @@ jobs:
       uses: actions/checkout@v4
 
     - name: 🐦‍⬛ Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
 
     - name: 🛠️ Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
 
     - name: 🪪 Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -58,7 +58,7 @@ jobs:
 
     - name: 🌳 Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v2
+      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076
 
     - name: 🔖 Get an old ImageTag
       run: |
@@ -66,7 +66,7 @@ jobs:
         --query 'imageIds[0].imageTag' --output text)" >> $GITHUB_ENV
 
     - name: 🚀 Build and Push
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
       with:
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -45,7 +45,7 @@ jobs:
           SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: 🐣 Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
         with:
           bun-version: canary
 

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: 🐣 Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
         with:
           bun-version: canary
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🐣 Install bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
         with:
           bun-version: canary
 


### PR DESCRIPTION
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/OpenUp-LabTakizawa/caravan-kidstec/pull/1409).
* __->__ #1409
* #1408

## Sourcery によるサマリー

再現性確保のため、すべてのサードパーティ製 GitHub Actions と bun のセットアップを、CI ワークフロー全体で特定のコミット SHA に固定し、コミット検証ワークフローにおける commitlint の範囲計算を修正します。

バグ修正:
- PR のベース SHA を開始点として使用するように commitlint の範囲計算を修正します。

CI:
- 決定性のある CI 実行のために、Docker、AWS、およびリンティング Actions (例: setup-qemu, setup-buildx, login, metadata, build-push, attest, scout) を固定コミット SHA に固定します。
- 一貫性のある bun 環境のために、複数のワークフローで oven-sh/setup-bun と autofix-ci/action の参照を特定のコミット SHA に更新します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Pin all third-party GitHub Actions and bun setup to specific commit SHAs across CI workflows for reproducibility, and correct the commitlint range calculation in the commit validation workflow.

Bug Fixes:
- Fix commitlint range calculation to use the PR base SHA as the starting point.

CI:
- Pin Docker, AWS, and linting Actions (e.g., setup-qemu, setup-buildx, login, metadata, build-push, attest, scout) to fixed commit SHAs for deterministic CI runs.
- Update oven-sh/setup-bun and autofix-ci/action references to specific commit SHAs in multiple workflows for consistent bun environment.

</details>