### PR TITLE
ci: ♻️reorder dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,24 @@
 version: 2
 updates:
+  - package-ecosystem: "bun"
+    directory:
+      - "/"
+      - "/docs"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "chore"
     groups:
       devcontainers:
         patterns:
@@ -12,6 +27,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "chore"
     groups:
       docker:
         patterns:
@@ -20,17 +37,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "ci"
     groups:
       ci:
-        patterns:
-          - "*"
-  - package-ecosystem: "bun"
-    directory:
-      - "/"
-      - "/docs"
-    schedule:
-      interval: "daily"
-    groups:
-      dependencies:
         patterns:
           - "*"


### PR DESCRIPTION
## Sourcery によるサマリー

Dependabot の設定を再編成し、bun エコシステムブロックを先頭に移動、重複エントリを削除、すべての更新ジョブに一貫した commit-message プレフィックスを追加します。

機能拡張:
- bun package-ecosystem ブロックを他の更新エントリよりも前に移動し、冗長な下部のエントリを削除しました
- bun、devcontainers、docker、および ci の更新ジョブに標準化された commit-message.prefix 設定を追加しました

CI:
- .github/dependabot.yml を更新して、各エコシステムの commit-message プレフィックスを含めました

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reorganize Dependabot configuration by moving the bun ecosystem block to the top, removing its duplicate entry, and adding consistent commit-message prefixes to all update jobs.

Enhancements:
- Move the bun package-ecosystem block to precede other update entries and remove its redundant bottom entry
- Add standardized commit-message.prefix settings for bun, devcontainers, docker, and ci update jobs

CI:
- Update .github/dependabot.yml to include commit-message prefixes for each ecosystem

</details>