### PR TITLE
build: remove bunfig.toml

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -143,7 +143,7 @@
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.68", "", { "os": "win32", "cpu": "x64" }, "sha512-2+bgC7ujhcx2XEl7sCdYAT6BIB7Y4eN5LuCII2p14gtQbvqBi7gFgd/UphLobarbSxhmaU/6D5cdSL2G0Yk2hQ=="],
 
-    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-05", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-05" }, "bin": { "playwright": "cli.js" } }, "sha512-d3R1qrHgKIpuvZeVDbSc6YfUWv5GXgAevKDX/xHZCqVJwY+BPNqjnnl3MmbgAUj5pO90bS6B2HlziyvZyo3emA=="],
+    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-06", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-06" }, "bin": { "playwright": "cli.js" } }, "sha512-d8EVgj2aFLWq7anFJbFg/2TbvaygUrK2SjaN+EhqvRi+KBIOO8z+W6AahJh6gWNUgtHNCCpWTOaCjgScdooi0Q=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
@@ -297,9 +297,9 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.54.0-alpha-2025-06-05", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-06-05" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-CKODBN4QyCOPZVr4DQT77P8gmJ8bD3EZTO6f0T2nJ8YJYcjhfSd9xUjybmCmIw1q5gfCiwCAgp6Ed0iLhXZYoA=="],
+    "playwright": ["playwright@1.54.0-alpha-2025-06-06", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-06-06" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-LoxuPYLnhxcizhOvE8ycVOOfjKsNkBAFyb3XsAbDjKBCPjHkEJ+LvxgSTqZnkJMubZ4E0eioKpFN8jrX8Gjt5Q=="],
 
-    "playwright-core": ["playwright-core@1.54.0-alpha-2025-06-05", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-IsuKgjfwsRqC5x3pQ/X+IJBj8zFOzKbxDmWjO8OIQKMzPDyoFCCYrI4lqOAYZ4ffmZeBdNXEu93ZrS+NYhduWA=="],
+    "playwright-core": ["playwright-core@1.54.0-alpha-2025-06-06", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-L57Jn2+3Q90cU3OtRqJbHxryrMnANJJ075UltpXMEmvur/zbXNe5R2t798gcco3eWmjrBqL7Bc9MK0xKjG6tXQ=="],
 
     "postcss": ["postcss@8.5.4", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,0 @@
-[test]
-preload = "./happydom.tsx"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "biome check --write",
-    "test:app": "bun test test/app",
+    "test:app": "bun test test/app --preload ./happydom.tsx",
     "test:e2e": "playwright test",
     "test:report": "playwright show-report"
   },


### PR DESCRIPTION
## Sourcery によるサマリー

レガシーな Bun の設定を削除し、テストスクリプトの統合を改善

機能拡張:
- `test:app` スクリプトを更新し、Bun テストのために happy-dom をプリロードするようにしました

雑務:
- `bunfig.toml` 設定ファイルを削除しました

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove legacy Bun configuration and refine test script integration

Enhancements:
- Update test:app script to preload happy-dom for Bun tests

Chores:
- Remove bunfig.toml configuration file

</details>