### PR TITLE
chore: remove sourcery-ai from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Marukome0743 @kazutan1230 @sourcery-ai
+* @Marukome0743 @kazutan1230


### PR DESCRIPTION
## Sourceryによるサマリー

雑務：
- .github/CODEOWNERS から sourcery-ai のエントリを削除

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Remove sourcery-ai entry from .github/CODEOWNERS

</details>