### PR TITLE
build: update dependencies

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -33,6 +33,6 @@ jobs:
         run: bun lint && bun biome ci --reporter=github
 
       - name: 💾 Commit
-        uses: autofix-ci/action@2891949f3779a1cafafae1523058501de3d4e944
+        uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27
         with:
           commit-message: "fix(autofix.ci): apply automated fixes"

--- a/bun.lock
+++ b/bun.lock
@@ -125,25 +125,25 @@
 
     "@line/bot-sdk": ["@line/bot-sdk@10.0.0", "", { "dependencies": { "@types/node": "^22.0.0" }, "optionalDependencies": { "axios": "^1.7.4" } }, "sha512-Uj6ZVivMDzZUV4Jm/RSsJinryyj3HS+fnyYob+mNl4/uUDWQ2OAEZDVopl0v0tcjXlCRC6GUB+nfEZLgBFI+dg=="],
 
-    "@next/env": ["@next/env@15.4.0-canary.70", "", {}, "sha512-hYJLeeXqPD3HLIYjsWkbrWqZJkk0mttXiQDpr3qdCjA6ZSazdAhciRo7RPdRW5Qd6K1Hh0jJoJoKLAGDmVv7nA=="],
+    "@next/env": ["@next/env@15.4.0-canary.71", "", {}, "sha512-8oQc5v+fcUR1HFC4I9zKYcWlhVZFKsWw3c+mqXCi206ucDjj8WhAJ+hHXcLo1C0oMwgZOvE+uAHYe+jMwzE1+g=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.0-canary.70", "", { "os": "darwin", "cpu": "arm64" }, "sha512-xIZIS5wmy1T7Ixhuw+ytD68rE0eYPuA5mEmBXZiGuZpNvR5S11S8SLJTgWeSqZlgUrR4Kc9DF8ZaQAW4ZN/YCA=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.0-canary.71", "", { "os": "darwin", "cpu": "arm64" }, "sha512-AHnZA1YZnCdUqO6eUQAhYyKAtambGxtdIhQag3JxMA908owuN/GhAh+nuuQyV6NFkpKqjjBXEDBNhhpAGsTnkg=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.0-canary.70", "", { "os": "darwin", "cpu": "x64" }, "sha512-rBwT3tz0n5bkopQ9u5M0T3wzWCgRdHVuRabcCgHe96bEUpgEDd1pt2PEAkw6hi8B7kIjOQBAkggXC2tjyosUbA=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.0-canary.71", "", { "os": "darwin", "cpu": "x64" }, "sha512-Genn24zWNUL0lBmt26xy2MeK5BmsnaQLW/fFSnxUXOXw/w1+29A6J46UcKu4k4W8tNgmqUD72IvmtmYjxGEeuw=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.0-canary.70", "", { "os": "linux", "cpu": "arm64" }, "sha512-YaFo7cGlYp2BuQBfNiXK1TtPGcr0L65247uBkADCPxMk2dQrz59CCU/xPZ2zgdvgF5tR1MWmvcPmi47b00vjAg=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.0-canary.71", "", { "os": "linux", "cpu": "arm64" }, "sha512-TCqAEscGfvJ1hvPMNikNneDjodbCtmbA6tS0oJjEg8G+MNuEPxfT98hiwwfevLtTENmcxX7gyfoIdyBrstDXbg=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.0-canary.70", "", { "os": "linux", "cpu": "arm64" }, "sha512-EZV6HmzFPbItxbZ2blfrI2Q7pAc0voaFgbhArpAicLezQtsuQZiUGZ99bPrQ4V+e1kYqxdZBrXs7IVISDAeAxA=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.0-canary.71", "", { "os": "linux", "cpu": "arm64" }, "sha512-PJtbZrlgS7U1FhaK0mLtCmfypM6cgEmLQC9TBD7t5Mh5XDJNS2rrqzyd15OK4tiNlpHTHcKYmLiMYxJGSFiD3w=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.0-canary.70", "", { "os": "linux", "cpu": "x64" }, "sha512-ZlY3EPt/mOhrPjqjPmm6o3RxyvuE+1Fd6HRvCTLVGBuX97v9grVvRvoahdz3EuMzWQfO4zxa4Esr0CJWCrEuAw=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.0-canary.71", "", { "os": "linux", "cpu": "x64" }, "sha512-lxIDl/1jusUcXXrU2KlO4gJGlCw82tSQ0QfVtoLB0FOWCSeiknakuyNtsplQ+SLk4+4uyPxW3G7wpXO+GdPYHw=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.0-canary.70", "", { "os": "linux", "cpu": "x64" }, "sha512-/IBf3ySAin+7GqnAo6mpaqpru8mpNNKx5pi17bDIjrwpwaBOOwJ5W3wh45Vid/osfE7bmky8a/5IzQ7Blx0GpA=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.0-canary.71", "", { "os": "linux", "cpu": "x64" }, "sha512-H+rZSpNOxfCwmAQLdq3XSHFPqRxe/55oL4jU36EiOVGKC+xlbZKesYUMytPiEXe46BbPH4z9/xMWdIC01NSDoA=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.0-canary.70", "", { "os": "win32", "cpu": "arm64" }, "sha512-kDydLMTiqANfG4mw5Zjx3yD5byQ2ibMlOmsm1Ha4IJEALQoizdjII9PmO8syBBEdZZgBYDESBzZr2zKFq1Ky4Q=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.0-canary.71", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gg3No0IPFSFUHNB/fKLsHgMY4L/f1xHthaFyTjFMxRDFI8Ll1rTu3a+iaIpiC8UaJ7pB5/aLHvrBOCS8ZFVIsw=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.70", "", { "os": "win32", "cpu": "x64" }, "sha512-kHAgKLoNf/8mJ1YlzkV+DYxuLUizusWBbdu6vV73/0BrhdE6fcwmxiR6xIYaGefPZVsoS4wVBB1JHD3yaOG/rw=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.71", "", { "os": "win32", "cpu": "x64" }, "sha512-y37nMDg+S+AzNWDTEvG9wVeDkjsu6nvIhoanbSC24dmH0DfZho5BF8tm1qVy6pL1c53j2UKUpyY3bUvlRj/f9g=="],
 
-    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-07", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-07" }, "bin": { "playwright": "cli.js" } }, "sha512-AweQ+izc5Zq29VpoqabvbBEa2NyXZE+JHxtPtkPk6t30vWKb2g7EGSJbr/67dDBPJXQHL2cg/spdP9VJLWx0Tw=="],
+    "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-08", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-08" }, "bin": { "playwright": "cli.js" } }, "sha512-kpWv2ykDo+VGw+f0zWfcBhwOUljZHnGFnUDx/ksW02lW7RTFST5KiLph5eznNoj70P3lnpLUBqZ2syo+d5lmYA=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
@@ -291,15 +291,15 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "next": ["next@15.4.0-canary.70", "", { "dependencies": { "@next/env": "15.4.0-canary.70", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.0-canary.70", "@next/swc-darwin-x64": "15.4.0-canary.70", "@next/swc-linux-arm64-gnu": "15.4.0-canary.70", "@next/swc-linux-arm64-musl": "15.4.0-canary.70", "@next/swc-linux-x64-gnu": "15.4.0-canary.70", "@next/swc-linux-x64-musl": "15.4.0-canary.70", "@next/swc-win32-arm64-msvc": "15.4.0-canary.70", "@next/swc-win32-x64-msvc": "15.4.0-canary.70", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-N8eAj+XJ/Gx1t16AIOyrXuGB9MYm09mbpkutUDWrJCL5Q9FmmYmlNiZIa0pr8zxSWxPQerOFh8GC5a6vlIPO4A=="],
+    "next": ["next@15.4.0-canary.71", "", { "dependencies": { "@next/env": "15.4.0-canary.71", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.0-canary.71", "@next/swc-darwin-x64": "15.4.0-canary.71", "@next/swc-linux-arm64-gnu": "15.4.0-canary.71", "@next/swc-linux-arm64-musl": "15.4.0-canary.71", "@next/swc-linux-x64-gnu": "15.4.0-canary.71", "@next/swc-linux-x64-musl": "15.4.0-canary.71", "@next/swc-win32-arm64-msvc": "15.4.0-canary.71", "@next/swc-win32-x64-msvc": "15.4.0-canary.71", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-BOi6jsq8RQDGZUms6oLRKysEBBKaDNJJx+KiS5V1yexabqU6jhkOWVYmoPdk7ksSRvlArZDEeR5ZebfdNNavOg=="],
 
     "next-view-transitions": ["next-view-transitions@0.3.4", "", { "peerDependencies": { "next": ">=14.0.0", "react": "^18.2.0", "react-dom": "^18.2.0" } }, "sha512-SSiskenQ8JkEFGzPjvFwC5LGGoqgTxM5dxexkeugxvcXFLpWI2ZUh4IsCURD3ovW+8Ue7xXlrtrpy8b7XR7IwQ=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "playwright": ["playwright@1.54.0-alpha-2025-06-07", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-06-07" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-YwdetrkIxZedwMk+h2aaDbr7NbmRIoxugCywsQW7AHd4s/3uPHNRLgt9+ZSd5Bin7cNheCJ7nHHIXzSzi2xqvA=="],
+    "playwright": ["playwright@1.54.0-alpha-2025-06-08", "", { "dependencies": { "playwright-core": "1.54.0-alpha-2025-06-08" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-wJkwhftzMwrAXveR8jThz9/rwN9uzIQC6oJxLV44d/ZCFEY5wYFoyktfDkmTcM/NSY8ygIDaavsAi1PzZbHkPQ=="],
 
-    "playwright-core": ["playwright-core@1.54.0-alpha-2025-06-07", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-uQs/L17UBZ/HQCRwr4r+pwY/OtwdUY5kyAqZmAw40sgnm/JXszKu6GM8x1LLu77e3ineIWcyp6FK2w64HbB4BQ=="],
+    "playwright-core": ["playwright-core@1.54.0-alpha-2025-06-08", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-eFXbQ3nUeRGEsTVFXxYIFefVsSSIUe4ikzgHM/05tc8ksImF0M1JOdGlMGEZDrS/zzeFhK+KDqsHr+86xNomKw=="],
 
     "postcss": ["postcss@8.5.4", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w=="],
 


### PR DESCRIPTION
## Sourcery によるサマリー

Autofix CI アクションのバージョンを上げ、Bun のロックファイルを再生成して、依存関係を更新します。

ビルド：
- autofix-ci/action GitHub Action を最新のコミットハッシュに更新

雑務：
- 更新された依存関係を反映するために bun.lock を再生成

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update dependencies by bumping the Autofix CI action version and regenerating the Bun lockfile.

Build:
- Bump autofix-ci/action GitHub Action to the latest commit hash

Chores:
- Regenerate bun.lock to reflect updated dependencies

</details>