### PR TITLE
build: update dependencies

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,9 +15,9 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@docusaurus/core": "3.8.1",
+    "@docusaurus/core": "^3.8.1",
     "@docusaurus/faster": "^3.8.1",
-    "@docusaurus/preset-classic": "3.8.1",
+    "@docusaurus/preset-classic": "^3.8.1",
     "@mdx-js/react": "^3.1.0",
     "clsx": "^2.1.1",
     "prism-react-renderer": "^2.4.1",
@@ -25,9 +25,9 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.8.1",
-    "@docusaurus/tsconfig": "3.8.1",
-    "@docusaurus/types": "3.8.1",
+    "@docusaurus/module-type-aliases": "^3.8.1",
+    "@docusaurus/tsconfig": "^3.8.1",
+    "@docusaurus/types": "^3.8.1",
     "typescript": "^5.8.3"
   },
   "browserslist": {


### PR DESCRIPTION
## Sourceryによるサマリー

`docs` パッケージの `package.json` 内の Docusaurus 依存関係にカレットバージョン範囲を使用し、非破壊的なアップデートを可能にします。

ビルド：
- `@docusaurus/core` および `@docusaurus/preset-classic` の依存関係を `^3.8.1` に切り替え
- `@docusaurus/module-type-aliases`、`@docusaurus/tsconfig`、および `@docusaurus/types` の `devDependencies` を `^3.8.1` に更新

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use caret version ranges for Docusaurus dependencies in the docs package.json to allow non-breaking updates

Build:
- Switch @docusaurus/core and @docusaurus/preset-classic dependencies to ^3.8.1
- Update @docusaurus/module-type-aliases, @docusaurus/tsconfig, and @docusaurus/types devDependencies to ^3.8.1

</details>