### PR TITLE
build: 🧰 use turbopack for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "dev-win": "WATCHPACK_POLLING=true next dev --turbopack",
-    "build": "next build",
+    "build": "next build --turbopack",
     "start": "next start",
     "lint": "biome check --write",
     "test:app": "bun test test/app --preload ./happydom.tsx",


### PR DESCRIPTION
## Sourceryによるサマリー

ビルド：
- `package.json`の`build`スクリプトに`--turbopack`フラグを追加し、本番ビルドでTurbopackを使用するようにしました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Add `--turbopack` flag to the `build` script in package.json to use Turbopack for production builds.

</details>