### PR TITLE
chore: add noUnusedImports rule to Biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,6 +8,9 @@
   },
   "linter": {
     "rules": {
+      "correctness": {
+        "noUnusedImports": "error"
+      },
       "nursery": {
         "useSortedClasses": "error"
       },


### PR DESCRIPTION
## Sourcery によるサマリー

機能拡張:
- `noUnusedImports` という linting rule を Biome の設定に追加しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Add noUnusedImports linting rule to the Biome configuration

</details>