### PR TITLE
chore: remove `useSortedClasses` rule due to error

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -11,9 +11,6 @@
       "correctness": {
         "noUnusedImports": "error"
       },
-      "nursery": {
-        "useSortedClasses": "error"
-      },
       "style": {
         "noUselessElse": "error",
         "useBlockStatements": "error"


### PR DESCRIPTION
## Sourceryによるサマリー

バグ修正:
- `biome.json`から`useSortedClasses`ルールを削除し、設定エラーを防ぎます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Drop the `useSortedClasses` rule from `biome.json` to prevent configuration errors

</details>