### PR TITLE
build: revert Dockerfile to use bun

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,24 @@
 # syntax=docker.io/docker/dockerfile-upstream:1.17.1-labs
 # check=error=true
-FROM node:24 AS builder
-WORKDIR /app
-RUN npm install -g bun@canary
-
+FROM oven/bun:canary AS builder
+WORKDIR /usr/src/app
 RUN --mount=type=bind,source=package.json,target=package.json \
   --mount=type=bind,source=bun.lock,target=bun.lock \
   --mount=type=cache,target=/root/.bun \
   bun i --frozen-lockfile
 COPY . .
-RUN bun test:app
-RUN bun run build
+RUN --mount=type=secret,id=database,env=DATABASE_URL \
+  bun test:app
+RUN --mount=type=secret,id=database,env=DATABASE_URL \
+  bun run build
 
 FROM gcr.io/distroless/nodejs24-debian12:nonroot
 WORKDIR /app
 COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 /lambda-adapter /opt/extensions/lambda-adapter
 
-COPY --from=builder /app/public ./public
-COPY --from=builder /app/.next/standalone ./
-COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /usr/src/app/public ./public
+COPY --from=builder /usr/src/app/.next/standalone ./
+COPY --from=builder /usr/src/app/.next/static ./.next/static
 
 EXPOSE 3000
 ENV AWS_LWA_ENABLE_COMPRESSION=true AWS_LWA_INVOKE_MODE=response_stream HOSTNAME=0.0.0.0 PORT=3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,8 @@ RUN --mount=type=bind,source=package.json,target=package.json \
   --mount=type=cache,target=/root/.bun \
   bun i --frozen-lockfile
 COPY . .
-RUN --mount=type=secret,id=database,env=DATABASE_URL \
-  bun test:app
-RUN --mount=type=secret,id=database,env=DATABASE_URL \
-  bun run build
+RUN bun test:app
+RUN bun run build
 
 FROM gcr.io/distroless/nodejs24-debian12:nonroot
 WORKDIR /app

--- a/bun.lock
+++ b/bun.lock
@@ -138,23 +138,23 @@
 
     "@module-federation/webpack-bundler-runtime": ["@module-federation/webpack-bundler-runtime@0.14.0", "", { "dependencies": { "@module-federation/runtime": "0.14.0", "@module-federation/sdk": "0.14.0" } }, "sha512-POWS6cKBicAAQ3DNY5X7XEUSfOfUsRaBNxbuwEfSGlrkTE9UcWheO06QP2ndHi8tHQuUKcIHi2navhPkJ+k5xg=="],
 
-    "@next/env": ["@next/env@15.4.0-canary.100", "", {}, "sha512-IQA5L/61sBDVWSoTYXkAeqr1MHp2QF31TkEFt/T+MPafqnYQZslKxeNOrHS3cfZSFBsDiXaIjYqJJ1eVAFVfJg=="],
+    "@next/env": ["@next/env@15.4.0-canary.102", "", {}, "sha512-g56fnHXgZEzLXpL6ycDACYaqJUXfEDQ/o3+hE3XUzNmQxYYH2UlTUamaw/h4F8GwvWdLG+fwKbXqCmKbWmzDIg=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.0-canary.100", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BigEN0/FBDDBCLaF5llOgeBc8lqNFMQ7r2OTV9xXdnMughsxjn1d0N1Op8sBMVQJtdW99dZYBzE5TnyBH8mdtg=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.0-canary.102", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kpQEYWarEfuO6I5BmQUUA22aHg8yhAbujCmPBezQEwwZFIqh+x8dokRPezvYLbyWOWU7vdIIb5LLE3/keB3C2g=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.0-canary.100", "", { "os": "darwin", "cpu": "x64" }, "sha512-44GM8TCu7YNuvS+2Q49nu1nIkILbXgvZdK/b3tpkO1NKsd9YpYqcpCHsiH95VxhnGzNL3t9M4IDWZpCI2Ir5Hw=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.0-canary.102", "", { "os": "darwin", "cpu": "x64" }, "sha512-rhvzIaJPRI4ElmzXgAnbD54Dr13ovEy4/aIMAr/xw3brmyZkdd3sLRPzQXKFAn8G9bRgjT2jWVX3t/AUsvEpqw=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.0-canary.100", "", { "os": "linux", "cpu": "arm64" }, "sha512-PM38Z4s8pJKca2F4rjs2FkhxukmXGFby8qVsjkO4etwmeiP7aM3dvvFKYA4VS4PsVJFmFwqR+GBSIBJ+ylStRg=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.0-canary.102", "", { "os": "linux", "cpu": "arm64" }, "sha512-PRgamgCOFVBGxwczyvbk3Pyxb7lWQfn8EXztlfp8C3q4hVgBoxF2Ezem8VfhFWA9EZfRZVCr3gEW6DoQkTWZsQ=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.0-canary.100", "", { "os": "linux", "cpu": "arm64" }, "sha512-0A2/50DmXW4SNeEcry0v+drR3mka3U5/pC6ASX7MjLDbXvRyuubo/mSn745k7tKU0skn27XRCRL4+twC/wBxAQ=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.0-canary.102", "", { "os": "linux", "cpu": "arm64" }, "sha512-v7hxc+YACprDhizTd5pxBq9w1Zf/alQgtasLSbKcmdgutBMCV2md5rGeik74iqYjbi/A7OC9QdurgrHlVG2vgQ=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.0-canary.100", "", { "os": "linux", "cpu": "x64" }, "sha512-3eE0EF2NCZWsUKxX2A6MugmA/NIYVveCJW5aVYnGv2z3ekzjkHg8XGkPTrJxLzyq0EKZDmlNLtP3s6Q2Pp8UPw=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.0-canary.102", "", { "os": "linux", "cpu": "x64" }, "sha512-LWlAeH3K2JgLsgk6bbzTyTlFQ6Ogu1/YKEcQY357jvt7/0IFxFgP299BWA2euizRK3Z296kW2KvygOYz+gJivg=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.0-canary.100", "", { "os": "linux", "cpu": "x64" }, "sha512-ZZ98ED6Kit9HOAczf3nWgKYTQeeFioCj0MY8DeQYq8QUB58lJGfBIef7e5CJwQzKNniDMLtL4gLUhFR+Ww62jA=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.0-canary.102", "", { "os": "linux", "cpu": "x64" }, "sha512-En9I5KJOT/JBor3rZH/MHViqwOct5VYNVe7hu0OsrwTomAxGrKjTDxsj8IYc7UZIIv44Omifv8RNh4FR4y4EEg=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.0-canary.100", "", { "os": "win32", "cpu": "arm64" }, "sha512-D8Rb+Qa/Fx3WfMeehUqRoQUHq1TdtwHU+Pi0TUJLTi9WZakY7Ozy3jOoZUX4kxvuVaqhObzsUvXKKG4Anas7KA=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.0-canary.102", "", { "os": "win32", "cpu": "arm64" }, "sha512-mWlL+Nw1Ra9NcFIDLYKpQNyirXwWs6eM3eIfLJPNtTie5cC46QAr+ykmxXzM4SngyfTjYHooRSavyAZaibwzUg=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.100", "", { "os": "win32", "cpu": "x64" }, "sha512-ioLcg+/YUDDPYyap6tFdECiauOEJLszx4fcDTh1Qw3s+Ed2G9ILYulOa0DgSjBUF3+XKddBMi89LD1j5VlNwKg=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.0-canary.102", "", { "os": "win32", "cpu": "x64" }, "sha512-ccod4eaV1OHXE56kl5mWDRPv1sO3FGNGACD2mgiiItl9uBJMIpxFGPwOjFs45Fq09MEQUPLBq0bPai6vhS5GQA=="],
 
     "@playwright/test": ["@playwright/test@1.54.0-alpha-2025-06-27", "", { "dependencies": { "playwright": "1.54.0-alpha-2025-06-27" }, "bin": { "playwright": "cli.js" } }, "sha512-HXEZ8/4G7UZjxYFI3KwvrkwzYOvTCr7KYcM8l0FHG1f1sk8s62Epuaa9xSvbs2ghE69tKzg/AOlxwpRHXLLo0g=="],
 
@@ -242,7 +242,7 @@
 
     "axios": ["axios@1.7.9", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.0", "proxy-from-env": "^1.1.0" } }, "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw=="],
 
-    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-02d78bb-20250626", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-wdoa0NNxaCl6LV7VX3GGkyuamxdh63YDlSKH3WfxCubNTj1/CXk0L5MOHVYFGTxK7pzcscVmM4Hi4BKhyaE0/A=="],
+    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-02d78bb-20250627", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-8oAj7DgonkKCHivnTNcsuezkxxQON+j5akCMXsFeiulhVwT+oX0Q6/M41rFPcJLtUFoKS9xCwVnn4B6gc4rK2A=="],
 
     "bun-types": ["bun-types@1.2.17", "", { "dependencies": { "@types/node": "*" } }, "sha512-ElC7ItwT3SCQwYZDYoAH+q6KT4Fxjl8DtZ6qDulUFBmXA8YB4xo+l54J9ZJN+k2pphfn9vk7kfubeSd5QfTVJQ=="],
 
@@ -336,9 +336,9 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "next": ["next@15.4.0-canary.100", "", { "dependencies": { "@next/env": "15.4.0-canary.100", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.0-canary.100", "@next/swc-darwin-x64": "15.4.0-canary.100", "@next/swc-linux-arm64-gnu": "15.4.0-canary.100", "@next/swc-linux-arm64-musl": "15.4.0-canary.100", "@next/swc-linux-x64-gnu": "15.4.0-canary.100", "@next/swc-linux-x64-musl": "15.4.0-canary.100", "@next/swc-win32-arm64-msvc": "15.4.0-canary.100", "@next/swc-win32-x64-msvc": "15.4.0-canary.100", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-dzazWhBeFDMWJMotDNNZaKOxxBXJjvNx9he37fUJigzUWTDXCjq0oOXWUjb+Yhs6wMzA6hUfSnPVWdaopFEkoA=="],
+    "next": ["next@15.4.0-canary.102", "", { "dependencies": { "@next/env": "15.4.0-canary.102", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.0-canary.102", "@next/swc-darwin-x64": "15.4.0-canary.102", "@next/swc-linux-arm64-gnu": "15.4.0-canary.102", "@next/swc-linux-arm64-musl": "15.4.0-canary.102", "@next/swc-linux-x64-gnu": "15.4.0-canary.102", "@next/swc-linux-x64-musl": "15.4.0-canary.102", "@next/swc-win32-arm64-msvc": "15.4.0-canary.102", "@next/swc-win32-x64-msvc": "15.4.0-canary.102", "sharp": "^0.34.1" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-udFH+SeNfkGfZq3B37YUwg54mBF0kV3KMeVukrQae9ZbG6H5qNP5fja8yCfoUOOogbIC8jMyfqErz85P3xNBpA=="],
 
-    "next-rspack": ["next-rspack@15.4.0-canary.100", "", { "dependencies": { "@rspack/core": "1.3.12", "@rspack/plugin-react-refresh": "1.2.0", "react-refresh": "0.12.0" } }, "sha512-AaFlCvumwFLlZsYVfXjkx0qmTdoumsMbAhMuGg62nuInaNZNy9frCg5nybZ6J4I5dzlULIqfjRZdcJEe1OT/xA=="],
+    "next-rspack": ["next-rspack@15.4.0-canary.102", "", { "dependencies": { "@rspack/core": "1.3.12", "@rspack/plugin-react-refresh": "1.2.0", "react-refresh": "0.12.0" } }, "sha512-pFIYfTLqqsSLoGT+HSgcD6zw7cgq4kWaXi2dMvADmcSE8NFKzyq9ZyNSgm8sN4CRGmeLXvUMMOmn9F8W4jRbjw=="],
 
     "next-view-transitions": ["next-view-transitions@0.3.4", "", { "peerDependencies": { "next": ">=14.0.0", "react": "^18.2.0", "react-dom": "^18.2.0" } }, "sha512-SSiskenQ8JkEFGzPjvFwC5LGGoqgTxM5dxexkeugxvcXFLpWI2ZUh4IsCURD3ovW+8Ue7xXlrtrpy8b7XR7IwQ=="],
 


### PR DESCRIPTION
## Sourceryによるサマリー

Dockerビルドを公式のbunイメージを使用するように戻し、ワークスペースのパスを標準化し、ビルドおよびテストコマンドをシークレットマウントで保護します。

機能拡張：
- Nodeにbunをインストールする代わりに、oven/bun:canaryをビルダーのベースとして使用します。
- 作業ディレクトリを/usr/src/appに切り替え、COPYパスを更新します。
- テストおよびビルドステップ中にDATABASE_URLのシークレットマウントを追加します。
- マウントされたキャッシュディレクトリを介してbunの依存関係のキャッシュを維持します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revert the Docker build to use the official bun image, standardize workspace paths, and secure the build and test commands with secret mounts

Enhancements:
- Use oven/bun:canary as the builder base instead of installing bun on Node
- Switch the working directory to /usr/src/app and update COPY paths
- Add secret mounts for DATABASE_URL during test and build steps
- Maintain bun dependency caching via a mounted cache directory

</details>