### PR TITLE
test: add missing className to Mock Image

### DIFF
--- a/happydom.tsx
+++ b/happydom.tsx
@@ -37,12 +37,21 @@ const mapNextImageSrcToString = (
 
 function MockNextImage({
   alt,
+  className,
   height,
   src: nextImageSrc,
   width,
 }: Readonly<ImageProps>): ReactElement {
   const imgSrc: string = mapNextImageSrcToString(nextImageSrc)
-  return <img alt={alt} height={height} src={imgSrc} width={width} />
+  return (
+    <img
+      alt={alt}
+      className={className}
+      height={height}
+      src={imgSrc}
+      width={width}
+    />
+  )
 }
 
 mock.module("next/image", (): EsModuleDefault<ComponentType<ImageProps>> => {


### PR DESCRIPTION
## Sourceryによるサマリー

機能拡張:
- `MockNextImage` の props に `className` を含め、レンダリングされた `<img>` に適用する

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Include `className` in `MockNextImage` props and apply it to the rendered `<img>`

</details>