### PR TITLE
ci: fix preview.yml

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -6,16 +6,6 @@ concurrency:
 
 on:
   pull_request_target:
-    types: [opened]
-    paths:
-      - "app/**"
-      - "public/**"
-      - "test/**"
-      - ".dockerignore"
-      - "bun.lock"
-      - "Dockerfile"
-      - "package.json"
-      - "*config.*"
 
 permissions:
   pull-requests: write
@@ -28,9 +18,20 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
+            const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '[![Open in Codeflow](https://developer.stackblitz.com/img/open_in_codeflow.svg)](https://pr.new/${{ github.repository }}/pull/${{ github.event.pull_request.number }}) *Run & review this pull request in [StackBlitz Codeflow](https://pr.new/${{ github.repository }}/pull/${{ github.event.pull_request.number }}).*'
+              issue_number: context.issue.number,
             })
+            const previewComment = comments.find(comment => {
+              return comment.user.type === 'Bot' && comment.body.includes('Open in Codeflow')
+            })
+
+            if (!previewComment) {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: '[![Open in Codeflow](https://developer.stackblitz.com/img/open_in_codeflow.svg)](https://pr.new/${{ github.repository }}/pull/${{ github.event.pull_request.number }}) *Run & review this pull request in [StackBlitz Codeflow](https://pr.new/${{ github.repository }}/pull/${{ github.event.pull_request.number }}).*'
+              })
+            }


### PR DESCRIPTION
## Sourceryによるサマリー

GitHubプレビューワークフローを更新し、すべてのプルリクエストで実行されるようにし、重複したプレビューコメントを防ぎます。

CI:
- `pull_request_target` タイプとパスフィルターを削除し、すべてのPRでプレビューワークフローがトリガーされるようにしました。
- 既存のコメントをリストし、StackBlitz Codeflowプレビューコメントがまだ存在しない場合にのみ投稿するロジックを追加しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the GitHub preview workflow to run on all pull requests and prevent duplicate preview comments

CI:
- Remove pull_request_target type and path filters to trigger the preview workflow on every PR
- Add logic to list existing comments and only post the StackBlitz Codeflow preview comment if it does not already exist

</details>