### PR TITLE
ci: remove checkout from lambda.yml

### DIFF
--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -25,7 +25,6 @@ on:
         type: boolean
 
 permissions:
-  contents: read
   id-token: write
 
 env:
@@ -40,9 +39,6 @@ jobs:
     if: github.repository_owner == 'openup-labtakizawa'
 
     steps:
-    - name: 📥 Checkout
-      uses: actions/checkout@v4
-
     - name: 🐦‍⬛ Set up QEMU
       uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
 
@@ -70,7 +66,6 @@ jobs:
       with:
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        context: .
         no-cache: ${{ inputs.no-cache == true }}
         platforms: linux/arm64
         provenance: false


### PR DESCRIPTION
## Sourcery によるサマリー

Lambda CI ワークフローを整理し、不要なステップと権限を削除します。

CI:
- `lambda.yml` から checkout action のステップを削除
- リポジトリの内容の読み取り権限を削除
- Docker ビルドコンテキストのパラメータを削除

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clean up the Lambda CI workflow by removing obsolete steps and permissions

CI:
- Remove the checkout action step from lambda.yml
- Drop the repository contents read permission
- Remove the Docker build context parameter

</details>