### PR TITLE
ci: update DOCKERHUB_USERNAME in docker.yml

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,7 @@ permissions:
   pull-requests: write
 
 env:
+  DOCKERHUB_USERNAME: marukome0743
   REPOSITORY: marukome0743/caravan-kidstec
   GHCR_REGISTRY: ghcr.io
   GHCR_REPOSITORY: openup-labtakizawa/caravan-kidstec
@@ -67,17 +68,11 @@ jobs:
         with:
           ref: ${{ env.SHA }}
 
-      - name: 🐦‍⬛ Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
-
-      - name: 🛠️ Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
-
       - name: 🐋 Login to Docker Hub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PAT }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: 🚢 Login to GitHub Container Registry
         if: fromJSON(env.IS_PUSH)
@@ -86,6 +81,12 @@ jobs:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🐦‍⬛ Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
+
+      - name: 🛠️ Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
 
       - name: ℹ️ Docker Meta
         id: meta


### PR DESCRIPTION
## Sourceryによるサマリー

GitHub ActionsのDockerワークフローを更新し、Docker Hubのユーザー名を環境変数に集約、Docker Hubへのログインをトークンベースに切り替え、QEMUとBuildxのセットアップ手順をコンテナレジストリへのログイン後に再配置しました。

CI:
- Docker Hub認証用にDOCKERHUB_USERNAME環境変数を追加
- Docker HubへのログインをDOCKERHUB_USERNAMEとDOCKERHUB_TOKENを使用するように切り替え
- QEMUとDocker Buildxのセットアップ手順をコンテナレジストリへのログイン手順の後に移動

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the GitHub Actions Docker workflow to centralize the Docker Hub username in an environment variable, switch to token-based login for Docker Hub, and reorder the QEMU and Buildx setup steps to after container registry logins.

CI:
- Add DOCKERHUB_USERNAME environment variable for Docker Hub authentication
- Switch Docker Hub login to use DOCKERHUB_USERNAME and DOCKERHUB_TOKEN
- Move QEMU and Docker Buildx setup steps to after container registry login steps

</details>