### PR TITLE
build: update Dockerfile for monorepo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@
 FROM oven/bun:canary AS builder
 WORKDIR /usr/src/app
 RUN --mount=type=bind,source=package.json,target=package.json \
+  --mount=type=bind,source=@caravan-kidstec/docs/package.json,target=@caravan-kidstec/docs/package.json \
+  --mount=type=bind,source=@caravan-kidstec/web/package.json,target=@caravan-kidstec/web/package.json \
   --mount=type=bind,source=bun.lock,target=bun.lock \
   --mount=type=cache,target=/root/.bun \
   bun i --frozen-lockfile
@@ -20,4 +22,4 @@ COPY --from=builder /usr/src/app/@caravan-kidstec/web/.next/static ./.next/stati
 
 EXPOSE 3000
 ENV AWS_LWA_ENABLE_COMPRESSION=true AWS_LWA_INVOKE_MODE=response_stream HOSTNAME=0.0.0.0 PORT=3000
-ENTRYPOINT ["/nodejs/bin/node", "server.js"]
+ENTRYPOINT ["/nodejs/bin/node", "@caravan-kidstec/web/server.js"]


### PR DESCRIPTION
## Sourceryによるサマリー

Dockerfileを更新して、追加のpackage.jsonファイルをバインドし、それに応じてサーバーのエントリーポイントパスを調整することで、モノレポパッケージをサポートします。

ビルド：
- ビルドステージ中に、@caravan-kidstec/docsおよび@caravan-kidstec/web package.jsonのバインドマウントを追加します。
- ENTRYPOINTを更新して、@caravan-kidstec/web/server.jsを指すようにします。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the Dockerfile to support monorepo packages by binding additional package.json files and adjust the server entrypoint path accordingly.

Build:
- Add bind mounts for @caravan-kidstec/docs and @caravan-kidstec/web package.json during the build stage
- Update ENTRYPOINT to point to @caravan-kidstec/web/server.js

</details>