### PR TITLE
test: change target iPhone device

### DIFF
--- a/@caravan-kidstec/web/playwright.config.ts
+++ b/@caravan-kidstec/web/playwright.config.ts
@@ -56,7 +56,7 @@ export default defineConfig({
     },
     {
       name: "Mobile Safari",
-      use: { ...devices["iPhone 12"] },
+      use: { ...devices["iPhone 16"] },
     },
 
     /* Test against branded browsers. */


### PR DESCRIPTION
## Sourcery によるサマリー

テスト:
- Playwright の設定で、モバイル Safari のテストデバイスを iPhone 12 から iPhone 16 に切り替えました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Switch Mobile Safari test device from iPhone 12 to iPhone 16 in Playwright configuration

</details>