### PR TITLE
chore: update commit types

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,9 +119,9 @@ The [Commit Message Footer](#commit-message-footer) format describes what the fo
   │       │             │
   │       │             └─⫸ Summary in present tense. Not capitalized. No period at the end.
   │       │
-  │       └─⫸ Commit Scope: biome|bun|ci|common|css|docker|git|security|test|vscode ...
+  │       └─⫸ Commit Scope: biome|bun|common|css|docker|git|security|vscode ...
   │
-  └─⫸ Commit Type: build|ci|docs|feat|fix|perf|refactor|test
+  └─⫸ Commit Type: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test
 ```
 
 The `<type>` and `<summary>` fields are mandatory, the `(<scope>)` field is optional.
@@ -154,7 +154,6 @@ The following is the example list of supported scopes:
 * `git`
 * `npm`
 * `security`
-* `test`
 * `vscode`
 * etc ...
 


### PR DESCRIPTION
## Sourcery によるサマリー

CONTRIBUTING.md のコミットメッセージ規約を更新し、廃止されたスコープを削除し、追加のコミットタイプを含めます。

ドキュメント：
- サポートされているコミットスコープから 'ci' および 'test' を削除
- コミットタイプに 'chore'、'revert'、および 'style' を追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update commit message conventions in CONTRIBUTING.md to remove obsolete scopes and include additional commit types

Documentation:
- Remove 'ci' and 'test' from supported commit scopes
- Add 'chore', 'revert', and 'style' to commit types

</details>