### PR TITLE
ci(GitHub): include Dockerfiles

### DIFF
--- a/.github/workflows/cleanup-cashes.yml
+++ b/.github/workflows/cleanup-cashes.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     paths:
       - "@caravan-kidstec/web/**"
+      - ".dockerignore"
       - "bun.lock"
+      - "Dockerfile"
       - "package.json"
     types:
       - closed

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,13 +8,17 @@ on:
   pull_request_target:
     paths:
       - "@caravan-kidstec/web/**"
+      - ".dockerignore"
       - "bun.lock"
+      - "Dockerfile"
       - "package.json"
   push:
     branches: main
     paths:
       - "@caravan-kidstec/web/**"
+      - ".dockerignore"
       - "bun.lock"
+      - "Dockerfile"
       - "package.json"
     tags:
       - "v*.*.*"

--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -9,7 +9,9 @@ on:
     branches: main
     paths:
       - "@caravan-kidstec/web/**"
+      - ".dockerignore"
       - "bun.lock"
+      - "Dockerfile"
       - "package.json"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,16 @@ on:
   pull_request_target:
     paths:
       - "@caravan-kidstec/web/**"
+      - ".dockerignore"
       - "bun.lock"
+      - "Dockerfile"
       - "package.json"
   push:
     paths:
       - "@caravan-kidstec/web/**"
+      - ".dockerignore"
       - "bun.lock"
+      - "Dockerfile"
       - "package.json"
   workflow_dispatch:
 


### PR DESCRIPTION
## Sourceryによるサマリー

CI:
- .dockerignoreとDockerfileのパスをdocker.yml、test.yml、cleanup-cashes.yml、lambda.ymlのワークフローのトリガーに追加しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Add .dockerignore and Dockerfile paths to triggers in docker.yml, test.yml, cleanup-cashes.yml, and lambda.yml workflows.

</details>