### PR TITLE
build(Docker): fix .next/static location

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,7 +11,6 @@
 biome.json
 CODE_OF_CONDUCT.md
 CONTRIBUTING.md
-docs
 LICENSE
 next-env.d.ts
 node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 /lambda-adapter /opt
 
 COPY --from=builder /usr/src/app/@caravan-kidstec/web/public ./@caravan-kidstec/web/public
 COPY --from=builder /usr/src/app/@caravan-kidstec/web/.next/standalone ./
-COPY --from=builder /usr/src/app/@caravan-kidstec/web/.next/static ./.next/static
+COPY --from=builder /usr/src/app/@caravan-kidstec/web/.next/static ./@caravan-kidstec/web/.next/static
 
 EXPOSE 3000
 ENV AWS_LWA_ENABLE_COMPRESSION=true AWS_LWA_INVOKE_MODE=response_stream HOSTNAME=0.0.0.0 PORT=3000


### PR DESCRIPTION
## Sourcery によるサマリー

ビルド:
- Dockerfile 内の `.next/static` のコピー先を、ウェブディレクトリの構造に合わせて修正しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Correct the .next/static copy destination in Dockerfile to match the web directory structure

</details>