### PR TITLE
ci: revert dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,6 @@ multi-ecosystem-groups:
 updates:
   - package-ecosystem: "bun"
     directories:
-      - "/"
       - "/@caravan-kidstec/*"
     schedule:
       interval: "daily"


### PR DESCRIPTION
## Sourcery によるサマリー

CI:
- .github/dependabot.yml 内の bun パッケージアップデートからルートディレクトリを削除しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Remove root directory from bun package updates in .github/dependabot.yml

</details>