### PR TITLE
feat: add status to api response

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -30,7 +30,7 @@ jobs:
         run: bun update
 
       - name: 🔷 Run Biome
-        run: bun check && bun biome ci --reporter=github
+        run: bun check
 
       - name: 💾 Commit
         uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27

--- a/@caravan-kidstec/web/app/api/bot/route.ts
+++ b/@caravan-kidstec/web/app/api/bot/route.ts
@@ -9,7 +9,7 @@ import { client } from "@/app/lib/line"
 export function GET(): Response {
   return Response.json({
     status: "success",
-  message: "Connected successfully!",
+    message: "Connected successfully!",
   })
 }
 


### PR DESCRIPTION
## Sourceryによる概要

APIエラー処理を改善し、適切なHTTPステータスコードを返し、レスポンスにリクエストIDを含めます。冗長なコードを削除し、自動修正CIワークフローを効率化します。

機能拡張:
- APIレスポンスで、バリデーションエラーに対してHTTP 400を、一般的なエラーに対してHTTP 500を返すようにしました。
- x-line-request-idを付与し、HTTP fetchエラーに対して実際のステータスコードを使用するようにしました。
- textEventHandlerの冗長なreturn文を削除しました。

CI:
- 自動修正GitHub ActionsワークフローからBiome CIステップを削除しました。

<details>
<summary>Original summary in English</summary>

## Sourceryによるサマリー

APIエラー処理を強化し、適切なHTTPステータスコードとリクエストIDを返すようにし、冗長性を排除してコードを効率化し、自動修正CIワークフローを簡素化します。

新機能：
- バリデーションエラーに対してHTTP 400、一般的なエラーに対してHTTP 500を返し、APIレスポンスにおけるHTTPフェッチエラーに対して実際のステータスコードを伝播します。
- HTTPフェッチ失敗のエラーレスポンスにx-line-request-idヘッダーの値を含めます。

機能拡張：
- textEventHandler内の冗長なreturn文を削除します。

CI：
- 自動修正GitHub ActionsワークフローからBiome CIステップを削除します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance API error handling to return proper HTTP status codes and request IDs, streamline code by removing redundancies, and simplify the autofix CI workflow.

New Features:
- Return HTTP 400 for validation errors, HTTP 500 for generic errors, and propagate actual status codes for HTTP fetch errors in API responses
- Include x-line-request-id header value in error responses for HTTP fetch failures

Enhancements:
- Remove redundant return statement in textEventHandler

CI:
- Remove Biome CI step from the autofix GitHub Actions workflow

</details>

</details>