### PR TITLE
docs: update GitHub Codespaces info

### DIFF
--- a/@caravan-kidstec/web/README.md
+++ b/@caravan-kidstec/web/README.md
@@ -15,7 +15,7 @@
   <a href="https://tailwindcss.com/"><img src="https://img.shields.io/badge/tailwind%20css-06B6D4?labelColor=000000&logo=tailwindcss&style=for-the-badge" alt="Tailwind CSS" /></a>
   <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/typescript-3178C6?labelColor=000000&logo=typescript&style=for-the-badge" alt="TypeScript" /></a>
   <a href="https://pr.new/github.com/OpenUp-LabTakizawa/caravan-kidstec"><img src="https://img.shields.io/badge/stackblitz-207BEA?labelColor=000000&logo=stackblitz&style=for-the-badge" alt="StackBlitz" /></a>
-  <a href="https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/OpenUp-LabTakizawa/caravan-kidstec"><img src="https://img.shields.io/badge/open-007ACC?label=dev%20containers&labelColor=000000&style=for-the-badge" alt="Dev Container" /></a>
+  <a href="https://github.com/codespaces/new/?repo=OpenUp-LabTakizawa/caravan-kidstec"><img src="https://img.shields.io/badge/open-007ACC?label=github%20codespaces&labelColor=000000&style=for-the-badge" alt="GitHub Codespaces" /></a>
   <a href="https://github.com/OpenUp-LabTakizawa/caravan-kidstec/blob/main/LICENSE"><img src="https://img.shields.io/github/license/OpenUp-LabTakizawa/caravan-kidstec?labelColor=000000&style=for-the-badge" alt="License" /></a>
 
   <p>
@@ -91,7 +91,11 @@ You can try out dev containers with **[GitHub Codespaces](https://github.com/fea
 
 <details>
 <summary>GitHub Codespaces</summary>
-  
+
+[![GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new/?repo=OpenUp-LabTakizawa/caravan-kidstec)  
+GitHub Codespaces is a cloud-based development environment that allows you to work on this project directly in your browser.  
+You can click the badge above or [here](https://github.com/codespaces/new/?repo=OpenUp-LabTakizawa/caravan-kidstec) to get started.
+
 Follow these steps to open this project in a Codespace:  
 1. Click the **Code** drop-down menu.  
 2. Click on the **Codespaces** tab.  
@@ -103,9 +107,6 @@ For more info, check out the [GitHub documentation](https://docs.github.com/en/c
 
 <details>
 <summary>VSCode Dev Containers</summary>
-  
-If you already have VSCode and [Docker](https://www.docker.com/) installed, you can click the badge above or [here](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/OpenUp-LabTakizawa/caravan-kidstec) to get started.  
-Clicking these links will cause VSCode to automatically install the Dev Containers extension if needed, clone the source code into a container volume, and spin up a dev container for use.
 
 Follow these steps to open this project in a container using the VSCode Dev Containers extension:
 


### PR DESCRIPTION
## Sourceryによる要約

プロジェクトのREADMEにおいて、dev containerバッジのリンクをCodespacesバッジに置き換え、バッジと手順を含む詳細なCodespaces使用セクションを挿入し、冗長なVSCode Dev Containersのガイダンスを削除することで、GitHub Codespacesのサポートを追加および強調表示します。

ドキュメント:
- READMEヘッダーのVSCode Dev ContainersバッジをGitHub Codespacesバッジに置き換えます。
- バッジ、説明、および起動リンクを含むCodespacesの詳細セクションを追加します。
- Codespacesセクションの下にある古いVSCode Dev Containersの手順を削除します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add and highlight GitHub Codespaces support in the project README by replacing the dev container badge link with a Codespaces badge, inserting a detailed Codespaces usage section with badge and instructions, and removing redundant VSCode Dev Containers guidance.

Documentation:
- Replace the VSCode Dev Containers badge with a GitHub Codespaces badge in the README header
- Add a Codespaces details section with badge, description, and startup link
- Remove outdated VSCode Dev Containers instructions under the Codespaces section

</details>