### PR TITLE
ci(dependabot): remove unnecessary directory settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
   - package-ecosystem: "bun"
     directories:
       - "/"
-      - "/@caravan-kidstec/*"
     schedule:
       interval: "daily"
     commit-message:


### PR DESCRIPTION
## Sourceryによる要約

CI:
- dependabot.ymlにおけるBunのアップデートから、冗長な`"@caravan-kidstec/*"`ディレクトリを削除しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Remove redundant "@caravan-kidstec/*" directory from bun updates in dependabot.yml

</details>