### PR TITLE
build: update dependencies

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: 👀 Validate current commit (last commit) with commitlint
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        run: bunx commitlint --last --verbose
+        run: bun commitlint --last --verbose
 
       - name: 👀 Validate PR commits with commitlint
         if: github.event_name == 'pull_request'
@@ -47,7 +47,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          bunx commitlint --from $BASE_SHA --to $HEAD_SHA --verbose \
+          bun commitlint --from $BASE_SHA --to $HEAD_SHA --verbose \
           &> >(tee -p commitlint.log) || STATUS=$?
           if [ $STATUS -ne 0 ]; then
             echo "is_success=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/pull-request-title-lint.yml
+++ b/.github/workflows/pull-request-title-lint.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          echo "$TITLE" | bunx commitlint --verbose &> >(tee -p commitlint.log) || STATUS=$?
+          echo "$TITLE" | bun commitlint --verbose &> >(tee -p commitlint.log) || STATUS=$?
           if [ $STATUS -ne 0 ]; then
             echo "is_success=false" >> $GITHUB_OUTPUT
           else

--- a/bun.lock
+++ b/bun.lock
@@ -575,23 +575,23 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.0.1", "", { "dependencies": { "@emnapi/core": "^1.4.5", "@emnapi/runtime": "^1.4.5", "@tybys/wasm-util": "^0.10.0" } }, "sha512-KVlQ/jgywZpixGCKMNwxStmmbYEMyokZpCf2YuIChhfJA2uqfAKNEM8INz7zzTo55iEXfBhIIs3VqYyqzDLj8g=="],
 
-    "@next/env": ["@next/env@15.4.2-canary.20", "", {}, "sha512-/9gVTcC1skkRzX44V6fAlm44d7VR67B6ZdUldthdUMPyDDuoRxi2zFeyhBKOVTKm8fEXLSzmKRG7EGMwhwEYUg=="],
+    "@next/env": ["@next/env@15.4.2-canary.22", "", {}, "sha512-rkHeAihbOPSEU6fsHJESKZVSD4USg/2dGLScS0t5Fgl9eKSE9wK5g/tov5sP02lHr2FPvq71gVtlPmOOCdW/SA=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.2-canary.20", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7bIlVw51uCQJXDnYj5yO6eXCP4jHIASfGIJ1mluAlZOsgrvsUH0OMncLkVUfAFCTYghNFE1U6DXXGt4PUNLjcA=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.2-canary.22", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tR9iTzo9zwKA2/wSRA5SLNGqXBOpUWqyYAUrbbSGKL3vRNVFMkimWxTqjj4hOGTCH4jYRIQ0mLaeBgAYaRrKsg=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.2-canary.20", "", { "os": "darwin", "cpu": "x64" }, "sha512-HUOAeB09uJtNHiHSgAb3i9UAQ1d8UrepHNC12E7D3nQp9gq9Q2JwVzzb9fjdB5dHmg6a5oje5TUMVpV2uet2Ag=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.2-canary.22", "", { "os": "darwin", "cpu": "x64" }, "sha512-XZAzK5pOqpIOhAvJ0yC0ATVCAW/YhJCMasedJ2djWIqtXrGWRVzOHJbaz1guPD9XnRSVKITOd9l4WdnOr+KPYA=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.2-canary.20", "", { "os": "linux", "cpu": "arm64" }, "sha512-p6eugWYtOVsKlR85gHVNiMWNBSI8mMjmMfKOrkluNsSJYoU5OJjkm9H2KystQbO4AkQIYs3SZnpDP6nfBk52Qw=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.2-canary.22", "", { "os": "linux", "cpu": "arm64" }, "sha512-0d/szF2bLGqt9EOgrYEOzHVoxYomfKfmQ+Ajs8hbjVsRlFCc/Gzmpuz5VcvY1cNVxoDPEwozsAA9LFUNdrnCUA=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.2-canary.20", "", { "os": "linux", "cpu": "arm64" }, "sha512-/OfWjsPybna0nWlbL2j24IFIHbefD7DKk6nLupNBbgAU9jcQAEn7uUIxfPzt9QJvA3Li0RAXyt3Iafe+Wdx/rA=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.2-canary.22", "", { "os": "linux", "cpu": "arm64" }, "sha512-Hz3g3eSYT1tHLMqoeo+pwNM5F7McJQKLNYwYVsQeeNxfXJU+W8ED3ED/0dXkkC60xr7YylG5xIVNZA5mz1cSUQ=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.2-canary.20", "", { "os": "linux", "cpu": "x64" }, "sha512-Y/uP1M2YW0Ox45Bq1gx5yyxPXGIexd2rFuJDvwc0h+KpKiO6Lu5Ria2kApFwqdAwyajGh5P+wfdJqKxGXK28vw=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.2-canary.22", "", { "os": "linux", "cpu": "x64" }, "sha512-d+x3fupEOMCG9LFWSF8CWsyvkGJDItIaNHZETNO3e9nCuOJLdlC+XVBDub/Sd9DFfLq/Qo9xmQWa5C5KepmqMw=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.2-canary.20", "", { "os": "linux", "cpu": "x64" }, "sha512-BppD+S9UAqbnk57vUjCCHlAxeUa5CfwDwc06Zs98trxJ7OLbzB38llzPhafKdHpthgDnzuj/00Cupxr6mwpclQ=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.2-canary.22", "", { "os": "linux", "cpu": "x64" }, "sha512-AMFPitGWSDemO2HvbexnFxpd3vlUAYUJ78UD564V7ByjPv/Bg1X3mDmTjoWrSlYl6s6HHZIVcqzMJRih84HVYw=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.2-canary.20", "", { "os": "win32", "cpu": "arm64" }, "sha512-Ukf7jXbOU+E40uYmvS9oUPE60ztVjpRH16x538Ftr1hYqYl39BXDXop5/ZOMxO6i9Q+MMcs8hNcbCNqiBO9+5w=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.2-canary.22", "", { "os": "win32", "cpu": "arm64" }, "sha512-eJzWPI6gmcRAiNCUsyOQ4QOt+loODDpcwgCReMmO4wS7INclk9ajr5QClmEIzWl6dHQCXoF5UKp+I5kBFhIESg=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.2-canary.20", "", { "os": "win32", "cpu": "x64" }, "sha512-+3EcVnJRqQK/k0Qql0ZLYgcGrTlkWty62cfoz6XyrW4B/etLrjwAUy8WnPhWNryPGzhNS8TvGyU2fi9ZjzYf/A=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.2-canary.22", "", { "os": "win32", "cpu": "x64" }, "sha512-OR5ktreHChoLNT8mcglXhvCl5Or4CDNaXd+sKCTlAHnUioKzSyM4JRLtualuZG2GocqquHA1FiJZ4Su9rSuomA=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -599,7 +599,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@playwright/test": ["@playwright/test@1.55.0-alpha-2025-07-29", "", { "dependencies": { "playwright": "1.55.0-alpha-2025-07-29" }, "bin": { "playwright": "cli.js" } }, "sha512-GQ6A7F+E7jQ+r5vl6hr9gE6WKUy7tYsA7HtqlS1G8ezrxKwcYg9qBrXHv/SL4cyDZT1K2Kqb4NwT/kEqhYHeIQ=="],
+    "@playwright/test": ["@playwright/test@1.55.0-alpha-1753913825000", "", { "dependencies": { "playwright": "1.55.0-alpha-1753913825000" }, "bin": { "playwright": "cli.js" } }, "sha512-YM5YHU6nTYNVzXlKvQvtEdXzpubLvdfEiTxwWvbqGHL/iDK2kBJd3L0psIG6yClU1wy01O756TkOOQSEpzOu7g=="],
 
     "@pnpm/config.env-replace": ["@pnpm/config.env-replace@1.1.0", "", {}, "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="],
 
@@ -963,7 +963,7 @@
 
     "babel-plugin-polyfill-regenerator": ["babel-plugin-polyfill-regenerator@0.6.5", "", { "dependencies": { "@babel/helper-define-polyfill-provider": "^0.6.5" }, "peerDependencies": { "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0" } }, "sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg=="],
 
-    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-10ec35e-20250729", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-zYdKkzZe8y0hbUJKGzk+rg9UJLj2aPvcW0/fzvzlBAQ5YSo20gNefcAzvTON0gsIFjONSAoB2VdWNNm4CbCwCg=="],
+    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-cffbb87-20250730", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-VRJOet4w4/5ePT2ksUBPPZnEHBsUGwKkQx44YDfVIayhOHgHaJXRi7kZLAoRLNcSbp0KqohOFSwCG8yIBgAC5A=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
@@ -1805,7 +1805,7 @@
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
-    "next": ["next@15.4.2-canary.20", "", { "dependencies": { "@next/env": "15.4.2-canary.20", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.2-canary.20", "@next/swc-darwin-x64": "15.4.2-canary.20", "@next/swc-linux-arm64-gnu": "15.4.2-canary.20", "@next/swc-linux-arm64-musl": "15.4.2-canary.20", "@next/swc-linux-x64-gnu": "15.4.2-canary.20", "@next/swc-linux-x64-musl": "15.4.2-canary.20", "@next/swc-win32-arm64-msvc": "15.4.2-canary.20", "@next/swc-win32-x64-msvc": "15.4.2-canary.20", "sharp": "^0.34.3" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.15.1", "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@modelcontextprotocol/sdk", "@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-0gZOqVyWg4iLfAWjpZK4YhwsfAnivJiJG5JPOcvMnrjuQEaBZeUGK4GjV4QO511S5ITkQsDV6rcL6IBoDBBGEA=="],
+    "next": ["next@15.4.2-canary.22", "", { "dependencies": { "@next/env": "15.4.2-canary.22", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.2-canary.22", "@next/swc-darwin-x64": "15.4.2-canary.22", "@next/swc-linux-arm64-gnu": "15.4.2-canary.22", "@next/swc-linux-arm64-musl": "15.4.2-canary.22", "@next/swc-linux-x64-gnu": "15.4.2-canary.22", "@next/swc-linux-x64-musl": "15.4.2-canary.22", "@next/swc-win32-arm64-msvc": "15.4.2-canary.22", "@next/swc-win32-x64-msvc": "15.4.2-canary.22", "sharp": "^0.34.3" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.15.1", "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@modelcontextprotocol/sdk", "@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-MPsw/JOJWZEBnPiFz7q9QE7oUtFf+dZUE9zo5CI7bc8f6iTL47/L1uq/ZU6XhP+JcKEvZCSGBPRKkFBkowq6jw=="],
 
     "next-view-transitions": ["next-view-transitions@0.3.4", "", { "peerDependencies": { "next": ">=14.0.0", "react": "^18.2.0", "react-dom": "^18.2.0" } }, "sha512-SSiskenQ8JkEFGzPjvFwC5LGGoqgTxM5dxexkeugxvcXFLpWI2ZUh4IsCURD3ovW+8Ue7xXlrtrpy8b7XR7IwQ=="],
 
@@ -1909,9 +1909,9 @@
 
     "pkg-dir": ["pkg-dir@7.0.0", "", { "dependencies": { "find-up": "^6.3.0" } }, "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA=="],
 
-    "playwright": ["playwright@1.55.0-alpha-2025-07-29", "", { "dependencies": { "playwright-core": "1.55.0-alpha-2025-07-29" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-OD/XArbF+1ALoGS8FSbq8SW/1oQE9u/ZLybGkSJftP2tAJAXFZPyfFHIrAOACCm5l1vtKq69V2sXfCouIOkkaw=="],
+    "playwright": ["playwright@1.55.0-alpha-1753913825000", "", { "dependencies": { "playwright-core": "1.55.0-alpha-1753913825000" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-IDyZzTu3tRNIjcx7/6ZmU7VmZPFGaW4jNsizwqbjSoeLFZPTLx2y693qeVVF/8KwEjuiSU3hVTQEzWvnx7cf2Q=="],
 
-    "playwright-core": ["playwright-core@1.55.0-alpha-2025-07-29", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-ubTmQ/yisGQ6XSnt/HeJyMpm7t5sDyXT+LQveNI0kzEhIVfEuQs6DaGom7zWH6MUD1KCs6R5z3Oyix1jM2juxw=="],
+    "playwright-core": ["playwright-core@1.55.0-alpha-1753913825000", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-FH5pHzLseQxD8+d2wGlRa/I32AzJ+ZzcdDNM1aiSw5+gmq+aOo3PBqXHvhsh7tj0h4l2Qf6z9qf4mMiwijVthw=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
@@ -2739,6 +2739,8 @@
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
+    "next-view-transitions/next": ["next@15.4.2-canary.20", "", { "dependencies": { "@next/env": "15.4.2-canary.20", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.2-canary.20", "@next/swc-darwin-x64": "15.4.2-canary.20", "@next/swc-linux-arm64-gnu": "15.4.2-canary.20", "@next/swc-linux-arm64-musl": "15.4.2-canary.20", "@next/swc-linux-x64-gnu": "15.4.2-canary.20", "@next/swc-linux-x64-musl": "15.4.2-canary.20", "@next/swc-win32-arm64-msvc": "15.4.2-canary.20", "@next/swc-win32-x64-msvc": "15.4.2-canary.20", "sharp": "^0.34.3" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.15.1", "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@modelcontextprotocol/sdk", "@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-0gZOqVyWg4iLfAWjpZK4YhwsfAnivJiJG5JPOcvMnrjuQEaBZeUGK4GjV4QO511S5ITkQsDV6rcL6IBoDBBGEA=="],
+
     "null-loader/schema-utils": ["schema-utils@3.3.0", "", { "dependencies": { "@types/json-schema": "^7.0.8", "ajv": "^6.12.5", "ajv-keywords": "^3.5.2" } }, "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
@@ -2867,6 +2869,30 @@
 
     "mdast-util-gfm-autolink-literal/micromark-util-character/micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
 
+    "next-view-transitions/next/@next/env": ["@next/env@15.4.2-canary.20", "", {}, "sha512-/9gVTcC1skkRzX44V6fAlm44d7VR67B6ZdUldthdUMPyDDuoRxi2zFeyhBKOVTKm8fEXLSzmKRG7EGMwhwEYUg=="],
+
+    "next-view-transitions/next/@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.2-canary.20", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7bIlVw51uCQJXDnYj5yO6eXCP4jHIASfGIJ1mluAlZOsgrvsUH0OMncLkVUfAFCTYghNFE1U6DXXGt4PUNLjcA=="],
+
+    "next-view-transitions/next/@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.2-canary.20", "", { "os": "darwin", "cpu": "x64" }, "sha512-HUOAeB09uJtNHiHSgAb3i9UAQ1d8UrepHNC12E7D3nQp9gq9Q2JwVzzb9fjdB5dHmg6a5oje5TUMVpV2uet2Ag=="],
+
+    "next-view-transitions/next/@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.2-canary.20", "", { "os": "linux", "cpu": "arm64" }, "sha512-p6eugWYtOVsKlR85gHVNiMWNBSI8mMjmMfKOrkluNsSJYoU5OJjkm9H2KystQbO4AkQIYs3SZnpDP6nfBk52Qw=="],
+
+    "next-view-transitions/next/@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.2-canary.20", "", { "os": "linux", "cpu": "arm64" }, "sha512-/OfWjsPybna0nWlbL2j24IFIHbefD7DKk6nLupNBbgAU9jcQAEn7uUIxfPzt9QJvA3Li0RAXyt3Iafe+Wdx/rA=="],
+
+    "next-view-transitions/next/@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.2-canary.20", "", { "os": "linux", "cpu": "x64" }, "sha512-Y/uP1M2YW0Ox45Bq1gx5yyxPXGIexd2rFuJDvwc0h+KpKiO6Lu5Ria2kApFwqdAwyajGh5P+wfdJqKxGXK28vw=="],
+
+    "next-view-transitions/next/@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.2-canary.20", "", { "os": "linux", "cpu": "x64" }, "sha512-BppD+S9UAqbnk57vUjCCHlAxeUa5CfwDwc06Zs98trxJ7OLbzB38llzPhafKdHpthgDnzuj/00Cupxr6mwpclQ=="],
+
+    "next-view-transitions/next/@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.2-canary.20", "", { "os": "win32", "cpu": "arm64" }, "sha512-Ukf7jXbOU+E40uYmvS9oUPE60ztVjpRH16x538Ftr1hYqYl39BXDXop5/ZOMxO6i9Q+MMcs8hNcbCNqiBO9+5w=="],
+
+    "next-view-transitions/next/@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.2-canary.20", "", { "os": "win32", "cpu": "x64" }, "sha512-+3EcVnJRqQK/k0Qql0ZLYgcGrTlkWty62cfoz6XyrW4B/etLrjwAUy8WnPhWNryPGzhNS8TvGyU2fi9ZjzYf/A=="],
+
+    "next-view-transitions/next/@playwright/test": ["@playwright/test@1.55.0-alpha-2025-07-29", "", { "dependencies": { "playwright": "1.55.0-alpha-2025-07-29" }, "bin": { "playwright": "cli.js" } }, "sha512-GQ6A7F+E7jQ+r5vl6hr9gE6WKUy7tYsA7HtqlS1G8ezrxKwcYg9qBrXHv/SL4cyDZT1K2Kqb4NwT/kEqhYHeIQ=="],
+
+    "next-view-transitions/next/babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-10ec35e-20250729", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-zYdKkzZe8y0hbUJKGzk+rg9UJLj2aPvcW0/fzvzlBAQ5YSo20gNefcAzvTON0gsIFjONSAoB2VdWNNm4CbCwCg=="],
+
+    "next-view-transitions/next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
     "null-loader/schema-utils/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
     "null-loader/schema-utils/ajv-keywords": ["ajv-keywords@3.5.2", "", { "peerDependencies": { "ajv": "^6.9.1" } }, "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="],
@@ -2907,6 +2933,8 @@
 
     "file-loader/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
+    "next-view-transitions/next/@playwright/test/playwright": ["playwright@1.55.0-alpha-2025-07-29", "", { "dependencies": { "playwright-core": "1.55.0-alpha-2025-07-29" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-OD/XArbF+1ALoGS8FSbq8SW/1oQE9u/ZLybGkSJftP2tAJAXFZPyfFHIrAOACCm5l1vtKq69V2sXfCouIOkkaw=="],
+
     "null-loader/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "renderkid/htmlparser2/domutils/dom-serializer": ["dom-serializer@1.4.1", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.0", "entities": "^2.0.0" } }, "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag=="],
@@ -2914,5 +2942,9 @@
     "url-loader/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "webpackbar/wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "next-view-transitions/next/@playwright/test/playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "next-view-transitions/next/@playwright/test/playwright/playwright-core": ["playwright-core@1.55.0-alpha-2025-07-29", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-ubTmQ/yisGQ6XSnt/HeJyMpm7t5sDyXT+LQveNI0kzEhIVfEuQs6DaGom7zWH6MUD1KCs6R5z3Oyix1jM2juxw=="],
   }
 }


### PR DESCRIPTION
## Sourceryによる要約

CIワークフローを更新し、commitlintに`bunx`の代わりに`bun`を使用し、`bun.lock`を更新します。

ビルド:
- 依存関係の更新後、`bun.lock`を再生成

CI:
- GitHubワークフロー内で、commitlintの呼び出しを`bunx`から`bun`に切り替え

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update CI workflows to use bun instead of bunx for commitlint and refresh bun.lock

Build:
- Regenerate bun.lock after updating dependencies

CI:
- Switch commitlint invocations from bunx to bun in GitHub workflows

</details>