### PR TITLE
refactor: remove unnecessary type assertion

### DIFF
--- a/@caravan-kidstec/web/app/carousel.tsx
+++ b/@caravan-kidstec/web/app/carousel.tsx
@@ -102,10 +102,7 @@ export function IndicatorCarousel(): JSX.Element {
 
   useEffect(() => {
     const carousel: HTMLDivElement = carouselRef.current as HTMLDivElement
-    const images: Map<string, HTMLImageElement> = imagesRef.current as Map<
-      string,
-      HTMLImageElement
-    >
+    const images: Map<string, HTMLImageElement> = imagesRef.current
     for (const node of [...images.values()].reverse()) {
       const newImage = node.cloneNode(true)
       carousel.prepend(newImage)
@@ -354,10 +351,7 @@ export function ReviewCarousel(): JSX.Element {
 
   useEffect(() => {
     const carousel: HTMLDivElement = carouselRef.current as HTMLDivElement
-    const reviews: Map<string, HTMLDivElement> = reviewsRef.current as Map<
-      string,
-      HTMLDivElement
-    >
+    const reviews: Map<string, HTMLDivElement> = reviewsRef.current
     for (const node of [...reviews.values()].reverse()) {
       const newReview = node.cloneNode(true)
       carousel.prepend(newReview)
@@ -366,10 +360,7 @@ export function ReviewCarousel(): JSX.Element {
 
   useEffect(() => {
     const carousel: HTMLDivElement = carouselRef.current as HTMLDivElement
-    const reviewsNode: Map<string, HTMLDivElement> = reviewsRef.current as Map<
-      string,
-      HTMLDivElement
-    >
+    const reviewsNode: Map<string, HTMLDivElement> = reviewsRef.current
     const reviewNode: HTMLDivElement = reviewsNode.get(
       reviews[0].description,
     ) as HTMLDivElement
@@ -383,10 +374,7 @@ export function ReviewCarousel(): JSX.Element {
 
   function ScrollEvent(): void {
     const carousel: HTMLDivElement = carouselRef.current as HTMLDivElement
-    const reviewsNode: Map<string, HTMLDivElement> = reviewsRef.current as Map<
-      string,
-      HTMLDivElement
-    >
+    const reviewsNode: Map<string, HTMLDivElement> = reviewsRef.current
     const reviewNode: HTMLDivElement = reviewsNode.get(
       reviews[0].description,
     ) as HTMLDivElement
@@ -432,9 +420,9 @@ export function ReviewCarousel(): JSX.Element {
         <div
           key={review.description}
           ref={(node: HTMLDivElement) => {
-            reviewsRef.current?.set(review.description, node)
+            reviewsRef.current.set(review.description, node)
             return () => {
-              reviewsRef.current?.delete(review.description)
+              reviewsRef.current.delete(review.description)
             }
           }}
           className="bg-blue-100 flex flex-col flex-none justify-between m-2 p-2 rounded-2xl shadow-lg snap-center text-sm w-56"

--- a/@caravan-kidstec/web/app/history/pictureTile.tsx
+++ b/@caravan-kidstec/web/app/history/pictureTile.tsx
@@ -32,7 +32,7 @@ export function PictureTile({
       }
     })
 
-    if (ref.current?.values()) {
+    if (ref.current.values()) {
       for (const node of ref.current.values()) {
         observer.observe(node)
       }
@@ -47,9 +47,9 @@ export function PictureTile({
           key={picture.alt}
           href={`${HISTORY.pathname}/image${pathname}/${date}/${picture.src.split("/")[5].split(".")[0]}`}
           ref={(node: HTMLAnchorElement) => {
-            ref.current?.set(picture.alt, node)
+            ref.current.set(picture.alt, node)
             return () => {
-              ref.current?.delete(picture.alt)
+              ref.current.delete(picture.alt)
             }
           }}
           className="cursor-zoom-in relative"


### PR DESCRIPTION
## Sourceryによる要約

carouselおよびpictureTileコンポーネント全体で、冗長な型アサーションと不要なオプショナルチェイニングを削除することにより、ref.currentの使用方法を簡素化します。

改善点:
- carouselおよびreviewコンポーネント内のref.currentへの代入における明示的な型アサーションを削除
- carouselおよびpictureTileコンポーネント内のref.currentマップからエントリを設定および削除する際の不要なオプショナルチェイニングを排除

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify usage of ref.current by removing redundant type assertions and unnecessary optional chaining across carousel and pictureTile components

Enhancements:
- Remove explicit type assertions on ref.current assignments in carousel and review components
- Eliminate unnecessary optional chaining when setting and deleting entries from ref.current maps in carousel and pictureTile components

</details>