### PR TITLE
ci: use success or failure condition

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -68,7 +68,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     needs: commitlint
-    if: always() && github.event_name == 'pull_request'
+    if: success() || failure() && github.event_name == 'pull_request'
 
     steps:
       - name: ❌ Create test failed comment

--- a/.github/workflows/pull-request-title-lint.yml
+++ b/.github/workflows/pull-request-title-lint.yml
@@ -58,7 +58,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     needs: lint-title
-    if: always()
+    if: success() || failure()
 
     steps:
       - name: ❌ Create test failed comment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
   upload:
     runs-on: ubuntu-latest
     needs: test
-    if: always() && github.event_name == 'pull_request'
+    if: success() || failure() && github.event_name == 'pull_request'
 
     steps:
       - name: ❌ Create test failed comment


### PR DESCRIPTION
## Sourceryによる要約

GitHub Actionsのワークフローを改善し、`always()` 条件を `success() || failure()` に置き換え、該当箇所に `pull_request` イベントのフィルタリングを追加しました。

CI:
- `commitlint`、`pull-request-title-lint`、および `test` ワークフローにおいて、アップロードジョブの条件を `always` ではなく `success` または `failure` の場合にのみ実行されるように標準化しました。
- `commitlint` および `test` のアップロードステップが `pull_request` イベントの場合にのみトリガーされるように制限しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine GitHub Actions workflows by replacing always() conditions with success() || failure() and adding pull_request event filtering where applicable

CI:
- Standardize upload job conditions to run only on success or failure instead of always in commitlint, pull-request-title-lint, and test workflows
- Restrict commitlint and test upload steps to trigger only on pull_request events

</details>