### PR TITLE
build: update dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -577,23 +577,23 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.0.3", "", { "dependencies": { "@emnapi/core": "^1.4.5", "@emnapi/runtime": "^1.4.5", "@tybys/wasm-util": "^0.10.0" } }, "sha512-rZxtMsLwjdXkMUGC3WwsPwLNVqVqnTJT6MNIB6e+5fhMcSCPP0AOsNWuMQ5mdCq6HNjs/ZeWAEchpqeprqBD2Q=="],
 
-    "@next/env": ["@next/env@15.4.2-canary.52", "", {}, "sha512-XftBBe1BDGq1L7xKIyRPzX8RZUD9UlIdcjFmBG5+IXG6du1cjMHHhxouXsHRCRmUeZfaChEX91LLfl4gKK1+YQ=="],
+    "@next/env": ["@next/env@15.4.2-canary.53", "", {}, "sha512-juxfIsEOWHaMNI9C4WRSXuHZzZiuTpsxB3s6J//T2n50t5ydpYPOD9SQU7+nQOSVlna3f/C79iIImKdrWKIABw=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.2-canary.52", "", { "os": "darwin", "cpu": "arm64" }, "sha512-99gUcFobDiECv7Vm40QWWi5sDanj5Ma9l7dYcqkQyTsszi63W9gCHymbjvHdf2HqtBVjHw/Z3MgRmHtsdgjLsw=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.2-canary.53", "", { "os": "darwin", "cpu": "arm64" }, "sha512-G8SjC499YfNFclaLYnA+DUrykAhX2NBJZKqQCenEz5lHgIc7/O465qqlcFdYsQPO0KU/+PBqtJYD3z+NOwSuKA=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.2-canary.52", "", { "os": "darwin", "cpu": "x64" }, "sha512-Cj/kcRwOnHNF4qDAWyYP6bGoY5HK+Zyk3H+BqDXwTtdkGMc9gECgWd/7lMUIEoKvD3A7uZYmDK0ZV1MnqsUslQ=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.2-canary.53", "", { "os": "darwin", "cpu": "x64" }, "sha512-jlFThDHlYCDByvUkn8+phJYINEPeNqJIaSM4J/TJKRPuEJPI2LixbUnfcPBOjtbfVqyoT9n0PsGYF1K3LZpH1w=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.2-canary.52", "", { "os": "linux", "cpu": "arm64" }, "sha512-WUBYVtOZXtlOeD3CiIe08kOskP/7HyeWf6T4joD7cPMt+als6OGXbUoSZwVrelziKRfX6r4EQJSw/jHAO1R96w=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.2-canary.53", "", { "os": "linux", "cpu": "arm64" }, "sha512-6PKLPOV0/bEiY1/3EBkhvFuJmHK9rIxRh54bWaVvZ5pE2EeCm0hf7cRuMc7mduF8d85ivL/PP6s9lgFyzUu33w=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.2-canary.52", "", { "os": "linux", "cpu": "arm64" }, "sha512-+a/7d4WgMq47m5vN1NZ2pyW3/7yYj7ecjyFjg/JLKbfdW23/QSv5E3l4ACVWRzL/BfvcreZ16+PqXBYY4BaLow=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.2-canary.53", "", { "os": "linux", "cpu": "arm64" }, "sha512-Bm+Yge7f+flOzpFG6CpsjmkejO8wyctsdgB5RLRhWzjh2OiJUfZpIbnqzfsHA6tn2xjyfa2WbRGtMpyi0vYf3w=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.2-canary.52", "", { "os": "linux", "cpu": "x64" }, "sha512-Cx7AqOnxi1XrZvHWQoroXp0mUFa8FA/J4JPdZeQunyD2zliAYBXn7a/uLD7aznOwBPUKCrf9YVCQNdXe5KDG2w=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.2-canary.53", "", { "os": "linux", "cpu": "x64" }, "sha512-1PQtFcNUMmMmNBq/i2b/dhG167P07H3iYF1cijzvjFCbEqrFY1pg0R1fGWaiDZazFkUV0W/P9hqM408DIT0tMQ=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.2-canary.52", "", { "os": "linux", "cpu": "x64" }, "sha512-CtLNhoowEbEnETlplMhdzmGrl4OnazA6YlAZDKTJQh2rZooASwCv8DpTz3OyqRjiI3mZ4IBKkf99lhzVI1jnKg=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.2-canary.53", "", { "os": "linux", "cpu": "x64" }, "sha512-HcL7xT++deaR7jwtrg1J3++jrD1Jncc7XLdB1rCuza3I7mK5dmUMZ+LSOGpyAZ0xRHFkXa/tL3e+KClxfTcZtA=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.2-canary.52", "", { "os": "win32", "cpu": "arm64" }, "sha512-kP8h8ysFoZmHyO+8Cw2r1Q3kN2d8XaD7XbeIMerpe+suoEitt6+tPTl92+n001yi8EMI5B3JxJ6JwPQZ0++ckQ=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.2-canary.53", "", { "os": "win32", "cpu": "arm64" }, "sha512-Iu/pQ5LmfwMwtj97wpQoYjbmCFPOYfoY/5uQKPisibVZAFKuJQo/gK4DjP7cvht0NE9ZiH2UGZNWtQ0KjTSadQ=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.2-canary.52", "", { "os": "win32", "cpu": "x64" }, "sha512-48PFmwZkosFsP56ssd1hCG7CXHnt5Ix0hCiU1jJ8cuEQOc5CiXUdihNFBYGPCjoYCTUYggcqpvu4NgyGNxK33g=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.2-canary.53", "", { "os": "win32", "cpu": "x64" }, "sha512-bRHL4UhuxEfrzws8mYs+lBItO6H96/kkYhzNcxIxQ8JUdK7YZ/lO/vng5n0tZ3mCzzA1HJEFiKToivZY/sT79g=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -601,7 +601,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@playwright/test": ["@playwright/test@1.55.0-alpha-2025-08-17", "", { "dependencies": { "playwright": "1.55.0-alpha-2025-08-17" }, "bin": { "playwright": "cli.js" } }, "sha512-Hm2obMwg4OCFjDYp8+myQ+tSxvX4JqoT5OHNRTbOnUgS/s4+TBXQpqD0qHA/enrCsQOuKMEB8Aw9sDmLzb6KDw=="],
+    "@playwright/test": ["@playwright/test@1.55.0-alpha-1755516433000", "", { "dependencies": { "playwright": "1.55.0-alpha-1755516433000" }, "bin": { "playwright": "cli.js" } }, "sha512-iBN6XN5z91eSLonoIjqcinRCXLQvegaTGeZtWQ/zkDcpigndSvd1fdxM3EmtONAnhMlhbTMUfYaRyq3MrXhW+Q=="],
 
     "@pnpm/config.env-replace": ["@pnpm/config.env-replace@1.1.0", "", {}, "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="],
 
@@ -965,7 +965,7 @@
 
     "babel-plugin-polyfill-regenerator": ["babel-plugin-polyfill-regenerator@0.6.5", "", { "dependencies": { "@babel/helper-define-polyfill-provider": "^0.6.5" }, "peerDependencies": { "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0" } }, "sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg=="],
 
-    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-6cef588-20250815", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-CSTud8RVNQefKhR53guWMu0mOZhND5YCvLdVizUbGLu06EntNNDBX3oLiPWgzXHquYqCQ8fWUUtR4LSrbpIBUA=="],
+    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-4083835-20250818", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-zwPnJhCENnU+KyXFqpu6ekwipFAjISwoZnx2/K+FZ2quX/k7Cu8fw77/s7AJ7QD7jNnrzPwABXAmeuPWK9A6iw=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
@@ -1807,7 +1807,7 @@
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
-    "next": ["next@15.4.2-canary.52", "", { "dependencies": { "@next/env": "15.4.2-canary.52", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.2-canary.52", "@next/swc-darwin-x64": "15.4.2-canary.52", "@next/swc-linux-arm64-gnu": "15.4.2-canary.52", "@next/swc-linux-arm64-musl": "15.4.2-canary.52", "@next/swc-linux-x64-gnu": "15.4.2-canary.52", "@next/swc-linux-x64-musl": "15.4.2-canary.52", "@next/swc-win32-arm64-msvc": "15.4.2-canary.52", "@next/swc-win32-x64-msvc": "15.4.2-canary.52", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-jR0ro18RatdNfzSKzxHB+6nSG4EJodN9uYvjnvHC7lb3x+pxy4gz3YylZxEwdOZw6i/rK3C0gjG/KSoP2jt1og=="],
+    "next": ["next@15.4.2-canary.53", "", { "dependencies": { "@next/env": "15.4.2-canary.53", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.2-canary.53", "@next/swc-darwin-x64": "15.4.2-canary.53", "@next/swc-linux-arm64-gnu": "15.4.2-canary.53", "@next/swc-linux-arm64-musl": "15.4.2-canary.53", "@next/swc-linux-x64-gnu": "15.4.2-canary.53", "@next/swc-linux-x64-musl": "15.4.2-canary.53", "@next/swc-win32-arm64-msvc": "15.4.2-canary.53", "@next/swc-win32-x64-msvc": "15.4.2-canary.53", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-5OYv9VGo3fEZqLXEV1NheiqBxodQO42WnvOWdycaYxGD/guK3pNWWNLDh7iWYEE/uYKlBHiuZjNkOaVw5gZ/Wg=="],
 
     "next-view-transitions": ["next-view-transitions@0.3.4", "", { "peerDependencies": { "next": ">=14.0.0", "react": "^18.2.0", "react-dom": "^18.2.0" } }, "sha512-SSiskenQ8JkEFGzPjvFwC5LGGoqgTxM5dxexkeugxvcXFLpWI2ZUh4IsCURD3ovW+8Ue7xXlrtrpy8b7XR7IwQ=="],
 
@@ -1911,9 +1911,9 @@
 
     "pkg-dir": ["pkg-dir@7.0.0", "", { "dependencies": { "find-up": "^6.3.0" } }, "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA=="],
 
-    "playwright": ["playwright@1.55.0-alpha-2025-08-17", "", { "dependencies": { "playwright-core": "1.55.0-alpha-2025-08-17" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-wjeDX9Uz7Iq6RrJGFNWn1bpxWmvhxlecbS7MYLEM1qd7RaqEnJ3kq8ejIIw2ZrJSd5aHcVm2SMtvihpAveD94Q=="],
+    "playwright": ["playwright@1.55.0-alpha-1755516433000", "", { "dependencies": { "playwright-core": "1.55.0-alpha-1755516433000" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-dErnRG5M4hpON0NSqNk1vo8hufN02UMtIxC8AUU1kVEUl3uYuKDBmc8D6Ha8AJ5Csazh2KtbJC4QgGEH985a6g=="],
 
-    "playwright-core": ["playwright-core@1.55.0-alpha-2025-08-17", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-fO7XNlsZ1JVEp8J3gfVovziLG8rnFQJeBo0K00q8nAscYIx+irIi6DyIBaiY0nmFQr3X7+rEsk3E28oAa1L1dw=="],
+    "playwright-core": ["playwright-core@1.55.0-alpha-1755516433000", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-mRyzKlwYwmMaWJbMRQda38w3I52Ea88HqaiM9ib3nW0lTYTebh/2LgN/E0vmW3VeV9DuYmU/JscIi4C50rEOzA=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
@@ -2739,6 +2739,8 @@
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
+    "next-view-transitions/next": ["next@15.4.2-canary.52", "", { "dependencies": { "@next/env": "15.4.2-canary.52", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.2-canary.52", "@next/swc-darwin-x64": "15.4.2-canary.52", "@next/swc-linux-arm64-gnu": "15.4.2-canary.52", "@next/swc-linux-arm64-musl": "15.4.2-canary.52", "@next/swc-linux-x64-gnu": "15.4.2-canary.52", "@next/swc-linux-x64-musl": "15.4.2-canary.52", "@next/swc-win32-arm64-msvc": "15.4.2-canary.52", "@next/swc-win32-x64-msvc": "15.4.2-canary.52", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-jR0ro18RatdNfzSKzxHB+6nSG4EJodN9uYvjnvHC7lb3x+pxy4gz3YylZxEwdOZw6i/rK3C0gjG/KSoP2jt1og=="],
+
     "null-loader/schema-utils": ["schema-utils@3.3.0", "", { "dependencies": { "@types/json-schema": "^7.0.8", "ajv": "^6.12.5", "ajv-keywords": "^3.5.2" } }, "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
@@ -2861,6 +2863,30 @@
 
     "mdast-util-gfm-autolink-literal/micromark-util-character/micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
 
+    "next-view-transitions/next/@next/env": ["@next/env@15.4.2-canary.52", "", {}, "sha512-XftBBe1BDGq1L7xKIyRPzX8RZUD9UlIdcjFmBG5+IXG6du1cjMHHhxouXsHRCRmUeZfaChEX91LLfl4gKK1+YQ=="],
+
+    "next-view-transitions/next/@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.2-canary.52", "", { "os": "darwin", "cpu": "arm64" }, "sha512-99gUcFobDiECv7Vm40QWWi5sDanj5Ma9l7dYcqkQyTsszi63W9gCHymbjvHdf2HqtBVjHw/Z3MgRmHtsdgjLsw=="],
+
+    "next-view-transitions/next/@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.2-canary.52", "", { "os": "darwin", "cpu": "x64" }, "sha512-Cj/kcRwOnHNF4qDAWyYP6bGoY5HK+Zyk3H+BqDXwTtdkGMc9gECgWd/7lMUIEoKvD3A7uZYmDK0ZV1MnqsUslQ=="],
+
+    "next-view-transitions/next/@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.2-canary.52", "", { "os": "linux", "cpu": "arm64" }, "sha512-WUBYVtOZXtlOeD3CiIe08kOskP/7HyeWf6T4joD7cPMt+als6OGXbUoSZwVrelziKRfX6r4EQJSw/jHAO1R96w=="],
+
+    "next-view-transitions/next/@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.2-canary.52", "", { "os": "linux", "cpu": "arm64" }, "sha512-+a/7d4WgMq47m5vN1NZ2pyW3/7yYj7ecjyFjg/JLKbfdW23/QSv5E3l4ACVWRzL/BfvcreZ16+PqXBYY4BaLow=="],
+
+    "next-view-transitions/next/@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.2-canary.52", "", { "os": "linux", "cpu": "x64" }, "sha512-Cx7AqOnxi1XrZvHWQoroXp0mUFa8FA/J4JPdZeQunyD2zliAYBXn7a/uLD7aznOwBPUKCrf9YVCQNdXe5KDG2w=="],
+
+    "next-view-transitions/next/@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.2-canary.52", "", { "os": "linux", "cpu": "x64" }, "sha512-CtLNhoowEbEnETlplMhdzmGrl4OnazA6YlAZDKTJQh2rZooASwCv8DpTz3OyqRjiI3mZ4IBKkf99lhzVI1jnKg=="],
+
+    "next-view-transitions/next/@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.2-canary.52", "", { "os": "win32", "cpu": "arm64" }, "sha512-kP8h8ysFoZmHyO+8Cw2r1Q3kN2d8XaD7XbeIMerpe+suoEitt6+tPTl92+n001yi8EMI5B3JxJ6JwPQZ0++ckQ=="],
+
+    "next-view-transitions/next/@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.2-canary.52", "", { "os": "win32", "cpu": "x64" }, "sha512-48PFmwZkosFsP56ssd1hCG7CXHnt5Ix0hCiU1jJ8cuEQOc5CiXUdihNFBYGPCjoYCTUYggcqpvu4NgyGNxK33g=="],
+
+    "next-view-transitions/next/@playwright/test": ["@playwright/test@1.55.0-alpha-2025-08-17", "", { "dependencies": { "playwright": "1.55.0-alpha-2025-08-17" }, "bin": { "playwright": "cli.js" } }, "sha512-Hm2obMwg4OCFjDYp8+myQ+tSxvX4JqoT5OHNRTbOnUgS/s4+TBXQpqD0qHA/enrCsQOuKMEB8Aw9sDmLzb6KDw=="],
+
+    "next-view-transitions/next/babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-6cef588-20250815", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-CSTud8RVNQefKhR53guWMu0mOZhND5YCvLdVizUbGLu06EntNNDBX3oLiPWgzXHquYqCQ8fWUUtR4LSrbpIBUA=="],
+
+    "next-view-transitions/next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
     "null-loader/schema-utils/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
     "null-loader/schema-utils/ajv-keywords": ["ajv-keywords@3.5.2", "", { "peerDependencies": { "ajv": "^6.9.1" } }, "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="],
@@ -2899,6 +2925,8 @@
 
     "file-loader/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
+    "next-view-transitions/next/@playwright/test/playwright": ["playwright@1.55.0-alpha-2025-08-17", "", { "dependencies": { "playwright-core": "1.55.0-alpha-2025-08-17" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-wjeDX9Uz7Iq6RrJGFNWn1bpxWmvhxlecbS7MYLEM1qd7RaqEnJ3kq8ejIIw2ZrJSd5aHcVm2SMtvihpAveD94Q=="],
+
     "null-loader/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "renderkid/htmlparser2/domutils/dom-serializer": ["dom-serializer@1.4.1", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.0", "entities": "^2.0.0" } }, "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag=="],
@@ -2906,5 +2934,9 @@
     "url-loader/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "webpackbar/wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "next-view-transitions/next/@playwright/test/playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "next-view-transitions/next/@playwright/test/playwright/playwright-core": ["playwright-core@1.55.0-alpha-2025-08-17", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-fO7XNlsZ1JVEp8J3gfVovziLG8rnFQJeBo0K00q8nAscYIx+irIi6DyIBaiY0nmFQr3X7+rEsk3E28oAa1L1dw=="],
   }
 }


### PR DESCRIPTION
## Sourceryによる要約

プロジェクトの依存関係を最新バージョンに更新するため、bun.lock を再生成します。

ビルド:
- 更新された依存関係のバージョンで bun.lock を更新

雑務:
- ロックファイルを更新して依存関係をバンプ

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Regenerate bun.lock to update project dependencies to their latest versions.

Build:
- Update bun.lock with refreshed dependency versions

Chores:
- Bump dependencies by refreshing the lockfile

</details>