### PR TITLE
ci: use aws-lambda-deploy action

### DIFF
--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -69,13 +69,13 @@ jobs:
         push: true
         tags: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
 
-    - name: 🥩 Update Lambda Function
-      env:
-        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        IMAGE_TAG: ${{ github.sha }}
-      run: |
-        aws lambda update-function-code --function-name $LAMBDA_FUNCTION_NAME \
-        --architectures arm64 --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+    - name: 🥩 Deploy Lambda function with container image
+      uses: aws-actions/aws-lambda-deploy@29ea35c124579506cf0475e20df36198eb670d89
+      with:
+        function-name: ${{ env.LAMBDA_FUNCTION_NAME }}
+        package-type: Image
+        image-uri: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
+        architectures: arm64
 
     - name: 🗑️ Delete an old Image
       run: |

--- a/bun.lock
+++ b/bun.lock
@@ -577,23 +577,23 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.0.3", "", { "dependencies": { "@emnapi/core": "^1.4.5", "@emnapi/runtime": "^1.4.5", "@tybys/wasm-util": "^0.10.0" } }, "sha512-rZxtMsLwjdXkMUGC3WwsPwLNVqVqnTJT6MNIB6e+5fhMcSCPP0AOsNWuMQ5mdCq6HNjs/ZeWAEchpqeprqBD2Q=="],
 
-    "@next/env": ["@next/env@15.5.1-canary.2", "", {}, "sha512-ZuKxRW7w9YFNkaDN+kKtPY3+jCSP9UnoUbpQ1Ti1rJzXET+0+QQr0V0lXCKjHC/2jP4DNnKxgIhSFPBR9Mx/jQ=="],
+    "@next/env": ["@next/env@15.5.1-canary.4", "", {}, "sha512-2btxnxNqEUfRsaEi0I5WNLf+ly0ihit+cxQZzhvnO9XxeXlTr4PAvDt7nuiDki6wCg6tniApjodqq6DhFp8NNA=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.5.1-canary.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Bc07kWSTOsJjkVS8Ziu3/U5sKRvhpb9gTTvwY4+bAw59DKMgvcQCir6Y9SCQSQFNPFAXkx51KOHx+fCF53gLRA=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.5.1-canary.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-beD8em1X39AzJ8I6xRnt89Q/hN3OvuUkJDey8/cYduoHhCxmdXpNY82jS1UslN8v192cEj4O7kNPWLlBrw9jpg=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.5.1-canary.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-jgysIpkAZJf1rBv1owOCOiwdZPid1uUZmmxE4vzbbXQOTimKfiRb6wAIPGV3w7REqDn+t2bkeGzRKOkFv5DNzA=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.5.1-canary.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-kriC0AVGMK/5ZXT+D7VTn7inU/ZtcUNfJPKPjcZIU2Wh+CIi2WzBUlUXnMsSv4fZgiuNhBi8M4y2FK0XB/r/bg=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.5.1-canary.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-yX5aqjbF7B+kKznD8kjgmNIeW3HmgA5XqaXVzSx1rjfyYfJ39JYfe32fk11c5zfcMnIyFinKK/2ZNc6qTI/bpw=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.5.1-canary.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-YVP8w7ihF9W84uAAVplORLI0JTvz1MkoR3AZVibQC2vxi9kTRdHvajam3N0/mDWSUj5d/IQtKRhGrPYk6WVmdg=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.5.1-canary.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-H7unAV8ue25Fa3YqyZNi0gCsQMW9EDQUDSobmTQr0oT8vCBEa+KUFUIZeiVf53Y5Pv5a8MAMLWVc1cbnkUGVWQ=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.5.1-canary.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Eq3Koc7ZYkpNviFCs5rDmrnWt6ar60lGtxlZcnJ2jIGzVEYB/9H/dbr9SmHJx8XdGo4dtVL8ycCR/sq+7E7npg=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.5.1-canary.2", "", { "os": "linux", "cpu": "x64" }, "sha512-2OZ+XC55GxOd6jfuyA+xbbgT8o8C8ynr+ciW9V5D1ZYRrtU2SqerG6p2YxIYXUGdyjl3qyUbB4cAbR46HNikNQ=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.5.1-canary.4", "", { "os": "linux", "cpu": "x64" }, "sha512-o9H72MJ3fHJTvwjVpZbGCt4470wtf3a8GvLNRVWzE08qtBl5bevnZvSFXEIIK+q24GBjGsOs9ZbGrPJ/utuZog=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.5.1-canary.2", "", { "os": "linux", "cpu": "x64" }, "sha512-5iJjG22m3XNgm2uLm2CFJ+iwhdm37Rc8OSPv7gL30vocLg6iPwp19cOlDRFRB2e2RRDVuamKy2v5VgZvMZNivQ=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.5.1-canary.4", "", { "os": "linux", "cpu": "x64" }, "sha512-ylFXmESywoXVT1vz/TuWCAHgvxJci5vvl9EbhIKtCU5PLkrWT54MOYVK9PpHPvn362wThhhbDBaI3DfTVO1U7A=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.5.1-canary.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-ci/XDfc9SeSGgsMo5xOjNEcvtRuqVn+NjcfckvSEthgqYlFSygSYTmjODoNW5ECaZ5Ti8PkRaSpNLgnPo1WPlw=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.5.1-canary.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-B9BMD55FWPqdDWgkXvxgRgRbzHK0yKLzhR3xw12f0VR0mD/XIqmZndqZwy0cCFld9Q1AoT+sSmY4DUC+Rw9T1Q=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.5.1-canary.2", "", { "os": "win32", "cpu": "x64" }, "sha512-PEiSgGyceR6l+hiFIPIj0yqqlzMyJ2Lxg/P3uDmflbE+D5k1BFxQuwVu8FM7USlkL5nax2+hnQami5KncqTW9Q=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.5.1-canary.4", "", { "os": "win32", "cpu": "x64" }, "sha512-4l2s0r1LL90aK/fOXvbyWV9nskkJb3TCvFx27T/nrsMRYsDzF3kcDi1S3VQ4lICznZ6igU8Ubm1yDZzb++QvvQ=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -965,7 +965,7 @@
 
     "babel-plugin-polyfill-regenerator": ["babel-plugin-polyfill-regenerator@0.6.5", "", { "dependencies": { "@babel/helper-define-polyfill-provider": "^0.6.5" }, "peerDependencies": { "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0" } }, "sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg=="],
 
-    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-4083835-20250820", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-AjLTeO9zA4OwiG6XD7K8o9yxn1JHsVCyvcAlEPzuE9XSPFBndUEvu14nZngw6RTQWGzZDH4CcnGXHAfJ/RhbEA=="],
+    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-4083835-20250821", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-EuJQet42pIA1BXFyOBFzDTlp6+mu27rtiKdXfxoceTAH/iWmdBD1qaJaGu5mw9GiMDMEJLvoPrGP70DptF3EDg=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
@@ -1807,7 +1807,7 @@
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
-    "next": ["next@15.5.1-canary.2", "", { "dependencies": { "@next/env": "15.5.1-canary.2", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.1-canary.2", "@next/swc-darwin-x64": "15.5.1-canary.2", "@next/swc-linux-arm64-gnu": "15.5.1-canary.2", "@next/swc-linux-arm64-musl": "15.5.1-canary.2", "@next/swc-linux-x64-gnu": "15.5.1-canary.2", "@next/swc-linux-x64-musl": "15.5.1-canary.2", "@next/swc-win32-arm64-msvc": "15.5.1-canary.2", "@next/swc-win32-x64-msvc": "15.5.1-canary.2", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-/1MtZWr0Juk3rbcwaJesaH8kQ/95k8lfjNq3Jc2Fz4PAVUTfrs2PjNQ3rWdtPcJxukYU2QQvvFFZsnnOIvD/Rw=="],
+    "next": ["next@15.5.1-canary.4", "", { "dependencies": { "@next/env": "15.5.1-canary.4", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.1-canary.4", "@next/swc-darwin-x64": "15.5.1-canary.4", "@next/swc-linux-arm64-gnu": "15.5.1-canary.4", "@next/swc-linux-arm64-musl": "15.5.1-canary.4", "@next/swc-linux-x64-gnu": "15.5.1-canary.4", "@next/swc-linux-x64-musl": "15.5.1-canary.4", "@next/swc-win32-arm64-msvc": "15.5.1-canary.4", "@next/swc-win32-x64-msvc": "15.5.1-canary.4", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-GPzm40zpB/oucI5lb84DT3+qktJp8YFZ9t7/lZwWdQqJb0ZfZiVvdZcoVr7niOOoHI3CU/97BRt9wsTO+GAJ8g=="],
 
     "next-view-transitions": ["next-view-transitions@0.3.4", "", { "peerDependencies": { "next": ">=14.0.0", "react": "^18.2.0", "react-dom": "^18.2.0" } }, "sha512-SSiskenQ8JkEFGzPjvFwC5LGGoqgTxM5dxexkeugxvcXFLpWI2ZUh4IsCURD3ovW+8Ue7xXlrtrpy8b7XR7IwQ=="],
 
@@ -2737,8 +2737,6 @@
 
     "micromark-util-subtokenize/micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
 
-    "next/@playwright/test": ["@playwright/test@1.56.0-alpha-2025-08-20", "", { "dependencies": { "playwright": "1.56.0-alpha-2025-08-20" }, "bin": { "playwright": "cli.js" } }, "sha512-FxvU2d5YuCwaq6ESNaJPAi/koEDai+WyRJx+4UcfeAo4xz+voH3uBEWstk2Lwkao1j9auvaeM+nDlgo0MQubfQ=="],
-
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "next-view-transitions/next": ["next@15.4.2-canary.52", "", { "dependencies": { "@next/env": "15.4.2-canary.52", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.2-canary.52", "@next/swc-darwin-x64": "15.4.2-canary.52", "@next/swc-linux-arm64-gnu": "15.4.2-canary.52", "@next/swc-linux-arm64-musl": "15.4.2-canary.52", "@next/swc-linux-x64-gnu": "15.4.2-canary.52", "@next/swc-linux-x64-musl": "15.4.2-canary.52", "@next/swc-win32-arm64-msvc": "15.4.2-canary.52", "@next/swc-win32-x64-msvc": "15.4.2-canary.52", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-jR0ro18RatdNfzSKzxHB+6nSG4EJodN9uYvjnvHC7lb3x+pxy4gz3YylZxEwdOZw6i/rK3C0gjG/KSoP2jt1og=="],
@@ -2885,9 +2883,9 @@
 
     "next-view-transitions/next/@playwright/test": ["@playwright/test@1.55.0-alpha-2025-08-17", "", { "dependencies": { "playwright": "1.55.0-alpha-2025-08-17" }, "bin": { "playwright": "cli.js" } }, "sha512-Hm2obMwg4OCFjDYp8+myQ+tSxvX4JqoT5OHNRTbOnUgS/s4+TBXQpqD0qHA/enrCsQOuKMEB8Aw9sDmLzb6KDw=="],
 
-    "next-view-transitions/next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+    "next-view-transitions/next/babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-4083835-20250820", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-AjLTeO9zA4OwiG6XD7K8o9yxn1JHsVCyvcAlEPzuE9XSPFBndUEvu14nZngw6RTQWGzZDH4CcnGXHAfJ/RhbEA=="],
 
-    "next/@playwright/test/playwright": ["playwright@1.56.0-alpha-2025-08-20", "", { "dependencies": { "playwright-core": "1.56.0-alpha-2025-08-20" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vIck+Po7jKPiVLkGLmhxYPW0Iux1Uhtqpqkzf0Z9jK+D2wYGYDGqlsEOqGbDcJiIxWmK14mByTCtN6LwfgCeMg=="],
+    "next-view-transitions/next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "null-loader/schema-utils/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
@@ -2928,10 +2926,6 @@
     "file-loader/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "next-view-transitions/next/@playwright/test/playwright": ["playwright@1.55.0-alpha-2025-08-17", "", { "dependencies": { "playwright-core": "1.55.0-alpha-2025-08-17" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-wjeDX9Uz7Iq6RrJGFNWn1bpxWmvhxlecbS7MYLEM1qd7RaqEnJ3kq8ejIIw2ZrJSd5aHcVm2SMtvihpAveD94Q=="],
-
-    "next/@playwright/test/playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
-
-    "next/@playwright/test/playwright/playwright-core": ["playwright-core@1.56.0-alpha-2025-08-20", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-zYBgXr6+VO3jYc23iNLS7OUS5cNZlAnEdsn/X9lqIO5GTfBINyn1KdyNuqgt00RoxEkgGhtPRFJRBpg6fph5hw=="],
 
     "null-loader/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 


### PR DESCRIPTION
## Sourceryによる要約

CI:
- 手動の `aws lambda update-function-code` ステップを、コンテナデプロイメント向けに `aws-actions/aws-lambda-deploy` アクションに置き換え

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Replace manual aws lambda update-function-code step with aws-actions/aws-lambda-deploy action for container deployments

</details>