### PR TITLE
ci: remove unnecessary condition

### DIFF
--- a/.github/workflows/pull-request-title-lint.yml
+++ b/.github/workflows/pull-request-title-lint.yml
@@ -35,7 +35,6 @@ jobs:
           ignores: [(message: string) => message.includes("Signed-off-by: dependabot[bot]")] }' > commitlint.config.ts
 
       - name: 👀 Validate PR title with commitlint
-        if: github.event_name == 'pull_request'
         id: commitlint
         env:
           TITLE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
## Sourceryによる要約

CI:
- commitlintステップを`pull_request`イベントに制限していた不要なif条件を削除

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Remove the unnecessary if condition restricting the commitlint step to pull_request events

</details>