### PR TITLE
feat: enable `typedRoutes` option

### DIFF
--- a/@caravan-kidstec/web/app/components/button/backButton.tsx
+++ b/@caravan-kidstec/web/app/components/button/backButton.tsx
@@ -1,4 +1,5 @@
 import { ArrowUturnLeftIcon } from "@heroicons/react/24/solid"
+import type { Route } from "next"
 import { Link } from "next-view-transitions"
 import type { JSX } from "react"
 import styles from "./backButton.module.css"
@@ -6,7 +7,7 @@ import styles from "./backButton.module.css"
 export function BackButton({
   href,
   name,
-}: Readonly<{ href: string; name: string }>): JSX.Element {
+}: Readonly<{ href: Route; name: string }>): JSX.Element {
   return (
     <Link
       href={href}

--- a/@caravan-kidstec/web/app/components/button/lineAddFriends.tsx
+++ b/@caravan-kidstec/web/app/components/button/lineAddFriends.tsx
@@ -1,4 +1,5 @@
 import { ArrowRightIcon } from "@heroicons/react/24/solid"
+import type { Route } from "next"
 import Image from "next/image"
 import Link from "next/link"
 import type { JSX } from "react"
@@ -7,7 +8,7 @@ import styles from "./lineAddFriends.module.css"
 
 export function LineAddFriends({
   linkLink,
-}: Readonly<{ linkLink: string }>): JSX.Element {
+}: Readonly<{ linkLink: Route }>): JSX.Element {
   return (
     <Bounce>
       <Link
@@ -30,7 +31,7 @@ export function LineAddFriends({
 
 export function LineApply({
   lineLink,
-}: Readonly<{ lineLink: string }>): JSX.Element {
+}: Readonly<{ lineLink: Route }>): JSX.Element {
   return (
     <Bounce>
       <Link
@@ -49,7 +50,7 @@ export function LineApply({
 export function LineRegister({
   areaName,
   lineLink,
-}: Readonly<{ areaName: string; lineLink: string }>): JSX.Element {
+}: Readonly<{ areaName: string; lineLink: Route }>): JSX.Element {
   return (
     <section className="bg-amber-50 mx-auto p-4 rounded-2xl space-y-2 text-center w-fit">
       <b>

--- a/@caravan-kidstec/web/app/history/image/[area]/[date]/[image]/page.tsx
+++ b/@caravan-kidstec/web/app/history/image/[area]/[date]/[image]/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next"
+import type { Metadata, Route } from "next"
 import Image from "next/image"
 import type { JSX } from "react"
 import { BackButton } from "@/app/components/button/backButton"
@@ -96,7 +96,7 @@ export default async function HistoryPicture({
   ) as Picture
   const movie: Menu = {
     name: eventDate.title,
-    pathname: `/${eventDate.date}`,
+    pathname: `/${eventDate.date}` as Route,
     textColor: "text-yellow-400",
   }
 

--- a/@caravan-kidstec/web/app/history/movie/[area]/[date]/page.tsx
+++ b/@caravan-kidstec/web/app/history/movie/[area]/[date]/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next"
+import type { Metadata, Route } from "next"
 import type { JSX } from "react"
 import { BackButton } from "@/app/components/button/backButton"
 import { Heading } from "@/app/components/layout/heading"
@@ -65,7 +65,7 @@ export default async function Movie({
   ) as EventDate
   const movie: Menu = {
     name: eventDate.title,
-    pathname: `/${eventDate.date}`,
+    pathname: `/${eventDate.date}` as Route,
     textColor: "text-yellow-400",
   }
 

--- a/@caravan-kidstec/web/app/history/page.tsx
+++ b/@caravan-kidstec/web/app/history/page.tsx
@@ -1,4 +1,5 @@
 import { MagnifyingGlassPlusIcon } from "@heroicons/react/24/solid"
+import type { Route } from "next"
 import { Link } from "next-view-transitions"
 import type { JSX } from "react"
 import { LineRegister } from "@/app/components/button/lineAddFriends"
@@ -55,7 +56,9 @@ export default function HistoryPage(): JSX.Element {
                   pictures={history.pictures}
                 />
                 <Link
-                  href={`${HISTORY.pathname}/movie${area.pathname}/${history.date}`}
+                  href={
+                    `${HISTORY.pathname}/movie${area.pathname}/${history.date}` as Route
+                  }
                   className={`bg-sky-400 button-pop cursor-zoom-in flex font-bold gap-2 items-center justify-center h-12 mt-2 mx-auto px-4 rounded-2xl shadow-lg text-lg text-white w-fit ${styles.blueShine}`}
                 >
                   イベントの様子はこちら！

--- a/@caravan-kidstec/web/app/history/pictureTile.tsx
+++ b/@caravan-kidstec/web/app/history/pictureTile.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { MagnifyingGlassPlusIcon } from "@heroicons/react/24/solid"
+import type { Route } from "next"
 import Image from "next/image"
 import { Link } from "next-view-transitions"
 import { type JSX, type RefObject, useEffect, useRef } from "react"
@@ -45,7 +46,9 @@ export function PictureTile({
       {pictures.map((picture) => (
         <Link
           key={picture.alt}
-          href={`${HISTORY.pathname}/image${pathname}/${date}/${picture.src.split("/")[5].split(".")[0]}`}
+          href={
+            `${HISTORY.pathname}/image${pathname}/${date}/${picture.src.split("/")[5].split(".")[0]}` as Route
+          }
           ref={(node: HTMLAnchorElement) => {
             ref.current.set(picture.alt, node)
             return () => {

--- a/@caravan-kidstec/web/app/interfaces/history.ts
+++ b/@caravan-kidstec/web/app/interfaces/history.ts
@@ -1,8 +1,9 @@
+import type { Route } from "next"
 import type { Menu } from "./menu.ts"
 import type { EventDate } from "./schedule.ts"
 
 export type History = {
   readonly area: Menu
   readonly history: EventDate[]
-  readonly lineLink: string
+  readonly lineLink: Route
 }

--- a/@caravan-kidstec/web/app/interfaces/menu.ts
+++ b/@caravan-kidstec/web/app/interfaces/menu.ts
@@ -1,6 +1,8 @@
+import type { Route } from "next"
+
 export type Menu = {
   readonly name: string
-  readonly pathname: string
+  readonly pathname: Route
   readonly textColor: string
 }
 

--- a/@caravan-kidstec/web/app/interfaces/partner.ts
+++ b/@caravan-kidstec/web/app/interfaces/partner.ts
@@ -1,8 +1,9 @@
+import type { Route } from "next"
 import type { Menu } from "./menu.ts"
 
 export type Partner = {
   readonly name: string
-  readonly href: string
+  readonly href: Route
   readonly src: string
   readonly introduction: string
 }

--- a/@caravan-kidstec/web/app/interfaces/sponser.ts
+++ b/@caravan-kidstec/web/app/interfaces/sponser.ts
@@ -1,6 +1,8 @@
+import type { Route } from "next"
+
 export type Sponser = {
   readonly name: string
-  readonly href: string
+  readonly href: Route
   readonly src: string
   readonly business: string
   readonly purpose: string

--- a/@caravan-kidstec/web/app/lib/constant.ts
+++ b/@caravan-kidstec/web/app/lib/constant.ts
@@ -1,3 +1,4 @@
+import type { Route } from "next"
 import type { Menu } from "@/app/interfaces/menu"
 import type { Partner } from "@/app/interfaces/partner"
 import type { Picture } from "@/app/interfaces/picture"
@@ -7,9 +8,9 @@ export const SITE_TITLE: string = "こどもテックキャラバン"
 export const SITE_URL: string = "https://caravan-kidstec.com"
 export const DESCRIPTION: string =
   "プログラミング×体験学習 親子で学ぶ体験型イベント"
-export const HIROSHIMA_LINE: string = "https://lin.ee/eYcNlkG"
-export const KANTO_LINE: string = "https://lin.ee/RHBWD7P"
-export const CLOUDFRONT_URL: string = "https://dk75m1tgsot44.cloudfront.net"
+export const HIROSHIMA_LINE: Route = "https://lin.ee/eYcNlkG"
+export const KANTO_LINE: Route = "https://lin.ee/RHBWD7P"
+export const CLOUDFRONT_URL: Route = "https://dk75m1tgsot44.cloudfront.net"
 
 export const HISTORY: Menu = {
   name: "活動実績",
@@ -33,27 +34,27 @@ export const SECRETARIAT: Menu = {
 }
 export const SPECIAL: Menu = {
   name: "スペシャル",
-  pathname: "/special",
+  pathname: "/special" as Route,
   textColor: "text-rose-400",
 }
 export const KANTO: Menu = {
   name: "関東",
-  pathname: "/kanto",
+  pathname: "/kanto" as Route,
   textColor: "",
 }
 export const HIROSHIMA: Menu = {
   name: "広島",
-  pathname: "/hiroshima",
+  pathname: "/hiroshima" as Route,
   textColor: "",
 }
 export const Q_AND_A: Menu = {
   name: "Q&A",
-  pathname: "/q-and-a",
+  pathname: "/q-and-a" as Route,
   textColor: "text-sky-400",
 }
 export const PRIVACY_POLICY: Menu = {
   name: "個人情報保護方針",
-  pathname: "/privacy-policy",
+  pathname: "/privacy-policy" as Route,
   textColor: "text-orange-400",
 }
 

--- a/@caravan-kidstec/web/app/partner/page.tsx
+++ b/@caravan-kidstec/web/app/partner/page.tsx
@@ -1,3 +1,4 @@
+import type { Route } from "next"
 import { Link } from "next-view-transitions"
 import type { JSX } from "react"
 import { Heading } from "@/app/components/layout/heading"
@@ -50,7 +51,7 @@ export default function SponserPage(): JSX.Element {
         >
           <h2 className="font-bold text-2xl sm:text-3xl">
             <Link
-              href={PARTNER.pathname + area.menu.pathname}
+              href={(PARTNER.pathname + area.menu.pathname) as Route}
               className={`block button-pop mx-auto underline w-fit ${area.color.text}`}
             >
               {area.menu.name}

--- a/@caravan-kidstec/web/app/secretariat/page.tsx
+++ b/@caravan-kidstec/web/app/secretariat/page.tsx
@@ -1,4 +1,5 @@
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline"
+import type { Route } from "next"
 import Image from "next/image"
 import Link from "next/link"
 import type { JSX } from "react"
@@ -76,7 +77,7 @@ export default function Secretariat(): JSX.Element {
               className="before:content-['・'] sm:flex"
             >
               <Link
-                href={organization.href}
+                href={organization.href as Route}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="font-bold inline-flex items-center text-sky-400 underline sm:mr-auto"

--- a/@caravan-kidstec/web/next.config.ts
+++ b/@caravan-kidstec/web/next.config.ts
@@ -13,6 +13,7 @@ const nextConfig: NextConfig = {
     remotePatterns: [new URL("https://dk75m1tgsot44.cloudfront.net/**")],
   },
   output: "standalone",
+  typedRoutes: true,
 }
 
 export default nextConfig


### PR DESCRIPTION
## Sourceryによる要約

Next.jsの`typedRoutes`オプションを有効化し、すべてのルート関連の値とプロパティをリファクタリングして、生文字列の代わりに`Route`型を使用するようにしました。

改善点:
- 定数およびコンポーネント全体で、メニューのパス名、スポンサー/パートナーの`href`、LINE/ナビゲーションリンクにNext.jsの`Route`型を適用
- `typedRoutes`の制約を満たすため、定数、インターフェース、ページ内でリテラルルート文字列を`Route`型にキャスト

ビルド:
- `next.config.ts`で`typedRoutes: true`を有効化

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable Next.js typedRoutes option and refactor all route-related values and props to use the `Route` type instead of raw strings.

Enhancements:
- Apply Next.js `Route` type to menu pathnames, sponsor/partner hrefs, and line/navigation links across constants and components
- Cast literal route strings to `Route` in constants, interfaces, and pages to satisfy typedRoutes constraints

Build:
- Enable `typedRoutes: true` in next.config.ts

</details>