### PR TITLE
ci: bump `attest-build-provenance` action from 2 to 3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: 🪪 Attest
         if: fromJSON(env.IS_PUSH)
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be
+        uses: actions/attest-build-provenance@v3
         with:
           subject-name: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPOSITORY }}
           subject-digest: ${{ steps.push.outputs.digest }}


### PR DESCRIPTION
## Sourceryによる要約

CI:
- .github/workflows/docker.yml で attest-build-provenance アクションをSHAからv3に更新しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Bump attest-build-provenance action from SHA to v3 in .github/workflows/docker.yml

</details>