### PR TITLE
build: update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker.io/docker/dockerfile-upstream:1.18.0-rc1-labs
+# syntax=docker.io/docker/dockerfile-upstream:1.18.0-rc2-labs
 # check=error=true
 FROM oven/bun:canary AS builder
 WORKDIR /usr/src/app

--- a/bun.lock
+++ b/bun.lock
@@ -605,7 +605,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@playwright/test": ["@playwright/test@1.56.0-alpha-2025-08-31", "", { "dependencies": { "playwright": "1.56.0-alpha-2025-08-31" }, "bin": { "playwright": "cli.js" } }, "sha512-PChOm7HrxNyN3wbUyVlfVakc4If3l1yBP8hu+KJOVrcmCqfrO2OUX245aNbTzhWsVmupowL83tOfxtpJzP6Nww=="],
+    "@playwright/test": ["@playwright/test@1.56.0-alpha-2025-09-01", "", { "dependencies": { "playwright": "1.56.0-alpha-2025-09-01" }, "bin": { "playwright": "cli.js" } }, "sha512-076KFGO1l6dX+k33C6mCpCvTJ0fWjhg0HHow/dr5+Tunnflf8lkSsBK+thk+gTlj3zTMfizTvcYF1H8UQe4anA=="],
 
     "@pnpm/config.env-replace": ["@pnpm/config.env-replace@1.1.0", "", {}, "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="],
 
@@ -1915,9 +1915,9 @@
 
     "pkg-dir": ["pkg-dir@7.0.0", "", { "dependencies": { "find-up": "^6.3.0" } }, "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA=="],
 
-    "playwright": ["playwright@1.56.0-alpha-2025-08-31", "", { "dependencies": { "playwright-core": "1.56.0-alpha-2025-08-31" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-/yB8hFi0gKOJDn0EHtlbdVX7Vu5fMNnN81kMuwXt/LIBTQGlU6qKIWUM1exKErFqpV3Ct1OM4qK2jNn5/TLoZA=="],
+    "playwright": ["playwright@1.56.0-alpha-2025-09-01", "", { "dependencies": { "playwright-core": "1.56.0-alpha-2025-09-01" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-WKc7c0KeJjgWLQ/KCTtGALGqz8sP/PF27pt6sweo2d11ZDRNh5Fz095zZceT8ABxzB1pjpftvYt2dyG5emi1IA=="],
 
-    "playwright-core": ["playwright-core@1.56.0-alpha-2025-08-31", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-Cc1saw8lWTrCzOIfvFJUGdLZXlz+aH3yPuLlpt2xHtvvcmrcbs7Ih/5xvhM0yggDcO9E2L5uOaHjYK0XhSgtwg=="],
+    "playwright-core": ["playwright-core@1.56.0-alpha-2025-09-01", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-tER9C21Q0xSkZxrpoPa0LkPOgygqGCwEQPPVJgi2AGOVrOwG42q07P5k0U5Oh0MUv+QvmF4cIb8BdG67dOjiUg=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
@@ -2755,6 +2755,8 @@
 
     "micromark-util-subtokenize/micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
 
+    "next/@playwright/test": ["@playwright/test@1.56.0-alpha-2025-08-31", "", { "dependencies": { "playwright": "1.56.0-alpha-2025-08-31" }, "bin": { "playwright": "cli.js" } }, "sha512-PChOm7HrxNyN3wbUyVlfVakc4If3l1yBP8hu+KJOVrcmCqfrO2OUX245aNbTzhWsVmupowL83tOfxtpJzP6Nww=="],
+
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "null-loader/schema-utils": ["schema-utils@3.3.0", "", { "dependencies": { "@types/json-schema": "^7.0.8", "ajv": "^6.12.5", "ajv-keywords": "^3.5.2" } }, "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg=="],
@@ -2881,6 +2883,8 @@
 
     "mdast-util-gfm-autolink-literal/micromark-util-character/micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
 
+    "next/@playwright/test/playwright": ["playwright@1.56.0-alpha-2025-08-31", "", { "dependencies": { "playwright-core": "1.56.0-alpha-2025-08-31" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-/yB8hFi0gKOJDn0EHtlbdVX7Vu5fMNnN81kMuwXt/LIBTQGlU6qKIWUM1exKErFqpV3Ct1OM4qK2jNn5/TLoZA=="],
+
     "null-loader/schema-utils/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
     "null-loader/schema-utils/ajv-keywords": ["ajv-keywords@3.5.2", "", { "peerDependencies": { "ajv": "^6.9.1" } }, "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="],
@@ -2918,6 +2922,10 @@
     "css-select/domutils/dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
 
     "file-loader/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "next/@playwright/test/playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "next/@playwright/test/playwright/playwright-core": ["playwright-core@1.56.0-alpha-2025-08-31", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-Cc1saw8lWTrCzOIfvFJUGdLZXlz+aH3yPuLlpt2xHtvvcmrcbs7Ih/5xvhM0yggDcO9E2L5uOaHjYK0XhSgtwg=="],
 
     "null-loader/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 


### PR DESCRIPTION
## Sourceryによる概要

Dockerビルダー構文のバージョンを更新およびプロジェクトのロックファイルを更新

ビルド:
- Dockerfileの構文を docker/dockerfile-upstream:1.18.0-rc2-labs に更新
- 依存関係を更新するため、bun.lock を更新

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Docker builder syntax version and refresh project lockfile

Build:
- Bump Dockerfile syntax to docker/dockerfile-upstream:1.18.0-rc2-labs
- Refresh bun.lock to update dependencies

</details>