### PR TITLE
feat: mark react compiler integration as stable

### DIFF
--- a/@caravan-kidstec/web/next.config.ts
+++ b/@caravan-kidstec/web/next.config.ts
@@ -5,7 +5,6 @@ const nextConfig: NextConfig = {
     inlineCss: true,
     isrFlushToDisk: false,
     ppr: true,
-    reactCompiler: true,
     viewTransition: true,
   },
   images: {
@@ -31,6 +30,7 @@ const nextConfig: NextConfig = {
     remotePatterns: [new URL("https://dk75m1tgsot44.cloudfront.net/**")],
   },
   output: "standalone",
+  reactCompiler: true,
   typedRoutes: true,
 }
 


### PR DESCRIPTION
## Sourceryによる要約

新機能:
- Reactコンパイラの統合を安定版に昇格させるため、`reactCompiler`フラグを実験的な設定からトップレベルのNext.js設定へ移動しました

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Promote React compiler integration to stable by moving reactCompiler flag from the experimental settings to the top-level Next.js configuration

</details>