### PR TITLE
ci: use pull_request event instead of pull_request_target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - "@caravan-kidstec/web/**"
       - ".dockerignore"


### PR DESCRIPTION
## Sourceryによる要約

CI:
- テストワークフローのトリガーを`pull_request_target`イベントではなく`pull_request`イベントに切り替える

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Switch test workflow trigger to pull_request event instead of pull_request_target

</details>