### PR TITLE
fix(autofix.ci): apply automated fixes

### DIFF
--- a/.mise/prepare-state.toml
+++ b/.mise/prepare-state.toml
@@ -1,3 +1,3 @@
 [providers.bun]
-"bun.lock" = "f69cb3d7909fc1b92baa3cb2466ad8cf8b4d3e0783081e79cffa5be09fe5d5bf"
+"bun.lock" = "0a009c340d436de5b32140f5e8388015b3073f2aa6dc4efdc8904f3d29019baa"
 "package.json" = "564968528592172c94195205dd7a439835359cf3c4beb55138eccf768af7b24a"

--- a/bun.lock
+++ b/bun.lock
@@ -618,7 +618,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@playwright/test": ["@playwright/test@1.60.0-alpha-1776125391000", "", { "dependencies": { "playwright": "1.60.0-alpha-1776125391000" }, "bin": { "playwright": "cli.js" } }, "sha512-Y/IaensPZ5bi4MOpdPZxxMw6lcmoL/K2VI3waxiCpWoV1S4/N3O/bo8iFKXTcpGAaNELZsvK+iI3u+yjQ14qiQ=="],
+    "@playwright/test": ["@playwright/test@1.60.0-alpha-2026-04-14", "", { "dependencies": { "playwright": "1.60.0-alpha-2026-04-14" }, "bin": { "playwright": "cli.js" } }, "sha512-pUgrMj7b+Fq/lfuja6Gce3XObUfgwKzhe9tGBVmMOKC2sfxVulzKzMEBwYccV7ccK2F+xdXraSJ6+Nq17G8+ug=="],
 
     "@pnpm/config.env-replace": ["@pnpm/config.env-replace@1.1.0", "", {}, "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="],
 
@@ -1902,9 +1902,9 @@
 
     "pkg-dir": ["pkg-dir@7.0.0", "", { "dependencies": { "find-up": "^6.3.0" } }, "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA=="],
 
-    "playwright": ["playwright@1.60.0-alpha-1776125391000", "", { "dependencies": { "playwright-core": "1.60.0-alpha-1776125391000" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-pyt0DqQqnsUrtO9AEQ9xizf04J7C61opRBedma7m0dSlWtKGIsvi979MJKemJQE/dFsa89wlYPyVGHrlDBe5tA=="],
+    "playwright": ["playwright@1.60.0-alpha-2026-04-14", "", { "dependencies": { "playwright-core": "1.60.0-alpha-2026-04-14" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-wrYNgIOWpw/vaC4TpFHx9mVYF7kM6bYyRbStIHfxfqHDZvj1rNcYKSiIBNSUA9qm4bye4PvPEDSpe3RqjYFX6A=="],
 
-    "playwright-core": ["playwright-core@1.60.0-alpha-1776125391000", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yzEKAtAuE1zBf1hcoGc7KVF0lj/T8haxlb8CcajNBuBNNVzXIuwLq8/WzwkPh9ZOyNSm7mMpulkdabETnhlktA=="],
+    "playwright-core": ["playwright-core@1.60.0-alpha-2026-04-14", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-Wkuhxvhg7YnJXJo+UomP4XlOhdH+AL2QdzJyLuHzqKEIxFkKqtSKF5TTfLt5gyB0UhqEO6knMpr5hULo3W6OEw=="],
 
     "postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
 
@@ -2758,6 +2758,8 @@
 
     "micromark-util-subtokenize/micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
 
+    "next/@playwright/test": ["@playwright/test@1.60.0-alpha-1776125391000", "", { "dependencies": { "playwright": "1.60.0-alpha-1776125391000" }, "bin": { "playwright": "cli.js" } }, "sha512-Y/IaensPZ5bi4MOpdPZxxMw6lcmoL/K2VI3waxiCpWoV1S4/N3O/bo8iFKXTcpGAaNELZsvK+iI3u+yjQ14qiQ=="],
+
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "next-view-transitions/next": ["next@16.2.1-canary.34", "", { "dependencies": { "@next/env": "16.2.1-canary.34", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.1-canary.34", "@next/swc-darwin-x64": "16.2.1-canary.34", "@next/swc-linux-arm64-gnu": "16.2.1-canary.34", "@next/swc-linux-arm64-musl": "16.2.1-canary.34", "@next/swc-linux-x64-gnu": "16.2.1-canary.34", "@next/swc-linux-x64-musl": "16.2.1-canary.34", "@next/swc-win32-arm64-msvc": "16.2.1-canary.34", "@next/swc-win32-x64-msvc": "16.2.1-canary.34", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-1frKeHysf1GVn5neMDADMWq/ITnkZzu4+4NLSqPFIyuGo44y/nCb9VncGjVdk89j7V0oJqaOL9HVl9OGNu2JDw=="],
@@ -2970,6 +2972,8 @@
 
     "next-view-transitions/next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
+    "next/@playwright/test/playwright": ["playwright@1.60.0-alpha-1776125391000", "", { "dependencies": { "playwright-core": "1.60.0-alpha-1776125391000" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-pyt0DqQqnsUrtO9AEQ9xizf04J7C61opRBedma7m0dSlWtKGIsvi979MJKemJQE/dFsa89wlYPyVGHrlDBe5tA=="],
+
     "null-loader/schema-utils/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
     "null-loader/schema-utils/ajv-keywords": ["ajv-keywords@3.5.2", "", { "peerDependencies": { "ajv": "^6.9.1" } }, "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="],
@@ -3017,6 +3021,10 @@
     "file-loader/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "next-view-transitions/next/@playwright/test/playwright": ["playwright@1.60.0-alpha-1775951570000", "", { "dependencies": { "playwright-core": "1.60.0-alpha-1775951570000" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-/+LszKoqmo/t61E9VheV2u+UGemg4Pu9GSTrTryOX4YUT/5BKxMNiRvZJdqDdk8F7oM0p8aox6swxD6MaD2ygQ=="],
+
+    "next/@playwright/test/playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "next/@playwright/test/playwright/playwright-core": ["playwright-core@1.60.0-alpha-1776125391000", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yzEKAtAuE1zBf1hcoGc7KVF0lj/T8haxlb8CcajNBuBNNVzXIuwLq8/WzwkPh9ZOyNSm7mMpulkdabETnhlktA=="],
 
     "null-loader/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 


### PR DESCRIPTION
## Summary by Sourcery

Bun の依存関係ロックファイルを更新し、mise の prepare-state 設定内のチェックサムと同期します。

Enhancements:
- Bun のロックファイルをリフレッシュし、最新の解決済み依存関係を反映。
- mise の prepare-state における Bun プロバイダのチェックサムを、更新後のロックファイルと整合させる。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Bun dependency lockfile and sync its checksum in the mise prepare-state configuration.

Enhancements:
- Refresh Bun lockfile to capture the latest resolved dependencies.
- Align mise prepare-state Bun provider checksum with the updated lockfile.

</details>