### PR TITLE
ci(playwright): parallelize browsers via matrix strategy

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -25,6 +25,25 @@ jobs:
   test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - project: chromium
+            browser: chromium
+            name: chromium
+          - project: firefox
+            browser: firefox
+            name: firefox
+          - project: webkit
+            browser: webkit
+            name: webkit
+          - project: Mobile Chrome
+            browser: chromium
+            name: mobile-chrome
+          - project: Mobile Safari
+            browser: webkit
+            name: mobile-safari
 
     steps:
       - name: 📥 Checkout
@@ -44,18 +63,21 @@ jobs:
         run: bun i
 
       - name: 🧩 Build app
+        working-directory: "@caravan-kidstec/web"
         run: bun run build
 
       - name: 🎭 Install Playwright Browsers
-        run: bun playwright install --with-deps
+        working-directory: "@caravan-kidstec/web"
+        run: bun playwright install --with-deps ${{ matrix.browser }}
 
       - name: 🧪 Run Playwright tests
-        run: bun test:e2e
+        working-directory: "@caravan-kidstec/web"
+        run: bun playwright test --project="${{ matrix.project }}"
 
       - name: 🆙 Upload Test Report
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report
-          path: playwright-report/
+          name: playwright-report-${{ matrix.name }}
+          path: "@caravan-kidstec/web/playwright-report/"
           retention-days: 30

--- a/@caravan-kidstec/web/playwright.config.ts
+++ b/@caravan-kidstec/web/playwright.config.ts
@@ -56,7 +56,7 @@ export default defineConfig({
     },
     {
       name: "Mobile Safari",
-      use: { ...devices["iPhone 16"] },
+      use: { ...devices["iPhone 15"] },
     },
 
     /* Test against branded browsers. */

--- a/bun.lock
+++ b/bun.lock
@@ -618,7 +618,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@playwright/test": ["@playwright/test@1.61.0-alpha-1778188671000", "", { "dependencies": { "playwright": "1.61.0-alpha-1778188671000" }, "bin": { "playwright": "cli.js" } }, "sha512-nyL+Zt6eCThBEBQmOaVfGlCEqT/YX1t5qdfbnqy4zrhPcmwAfrkBu6VHYVGqe90UmMduItgSlbfPt9egMA9R+g=="],
+    "@playwright/test": ["@playwright/test@1.61.0-alpha-2026-05-08", "", { "dependencies": { "playwright": "1.61.0-alpha-2026-05-08" }, "bin": { "playwright": "cli.js" } }, "sha512-5ZSWPs1XMkK53p1oZxdp4vasQi6Yz1SKEu7g024fy2yb5TQXkIX3ttbkA6PFCb7jQwPmc0P7ARxR2Lz3CI2t6w=="],
 
     "@pnpm/config.env-replace": ["@pnpm/config.env-replace@1.1.0", "", {}, "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="],
 
@@ -978,7 +978,7 @@
 
     "babel-plugin-polyfill-regenerator": ["babel-plugin-polyfill-regenerator@0.6.5", "", { "dependencies": { "@babel/helper-define-polyfill-provider": "^0.6.5" }, "peerDependencies": { "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0" } }, "sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg=="],
 
-    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-a1856f3-20260506", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-g78/lzvaGzEX9Qftn223Dv85LzLsyBmJqnHyN0kAwYfO2jxmFNoXCKhFvqvWSELlFOmpGScT1Ool7/nkCpj3dA=="],
+    "babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-a1856f3-20260507", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-NH/o9ojGrQ5xQhkLry8KulKssfWuM68myEGVUpIJhExt1/WVWBOTBPSPGiSRoJtfB9yP8Kj4UXZpLXKFCXineg=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
@@ -1900,9 +1900,9 @@
 
     "pkg-dir": ["pkg-dir@7.0.0", "", { "dependencies": { "find-up": "^6.3.0" } }, "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA=="],
 
-    "playwright": ["playwright@1.61.0-alpha-1778188671000", "", { "dependencies": { "playwright-core": "1.61.0-alpha-1778188671000" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-A6fFc7ExLRmvm0ZHqCyY2uHXSvEdpb8W+/HyIPK4ecRqNil8Mc1Vig1WFYoqk82x3+U9Qb571fQE95wgKqIQ1g=="],
+    "playwright": ["playwright@1.61.0-alpha-2026-05-08", "", { "dependencies": { "playwright-core": "1.61.0-alpha-2026-05-08" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-k0hlDeFZBs7TrcA5q/uy32HnXQG2XtrzMVxgna2ua1li1qOEiwfJYHY0FeKs8Gv+WMbPEzrBGJc/XI86NSPxoA=="],
 
-    "playwright-core": ["playwright-core@1.61.0-alpha-1778188671000", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-nsw2Crz0uZS3IRHiEcOXUt+RaKB/Hna+GAD4oD6cPqCHfJfW77cJdgktC0jzp3Ndyv23EJI3bcWSqFIiqSNE5A=="],
+    "playwright-core": ["playwright-core@1.61.0-alpha-2026-05-08", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-vmuQLxOH8j6paAyB3dUQCxrktOn2Zl3UxfCMYm7j2u1cFfs2jwAA7IY3UeNuXzrBspt66pPaDRqI8fXempBgIA=="],
 
     "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
@@ -2748,6 +2748,10 @@
 
     "micromark-util-subtokenize/micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
 
+    "next/@playwright/test": ["@playwright/test@1.61.0-alpha-1778188671000", "", { "dependencies": { "playwright": "1.61.0-alpha-1778188671000" }, "bin": { "playwright": "cli.js" } }, "sha512-nyL+Zt6eCThBEBQmOaVfGlCEqT/YX1t5qdfbnqy4zrhPcmwAfrkBu6VHYVGqe90UmMduItgSlbfPt9egMA9R+g=="],
+
+    "next/babel-plugin-react-compiler": ["babel-plugin-react-compiler@0.0.0-experimental-a1856f3-20260506", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-g78/lzvaGzEX9Qftn223Dv85LzLsyBmJqnHyN0kAwYfO2jxmFNoXCKhFvqvWSELlFOmpGScT1Ool7/nkCpj3dA=="],
+
     "next/postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
     "null-loader/schema-utils": ["schema-utils@3.3.0", "", { "dependencies": { "@types/json-schema": "^7.0.8", "ajv": "^6.12.5", "ajv-keywords": "^3.5.2" } }, "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg=="],
@@ -2932,6 +2936,8 @@
 
     "mdast-util-gfm-autolink-literal/micromark-util-character/micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
 
+    "next/@playwright/test/playwright": ["playwright@1.61.0-alpha-1778188671000", "", { "dependencies": { "playwright-core": "1.61.0-alpha-1778188671000" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-A6fFc7ExLRmvm0ZHqCyY2uHXSvEdpb8W+/HyIPK4ecRqNil8Mc1Vig1WFYoqk82x3+U9Qb571fQE95wgKqIQ1g=="],
+
     "null-loader/schema-utils/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
     "null-loader/schema-utils/ajv-keywords": ["ajv-keywords@3.5.2", "", { "peerDependencies": { "ajv": "^6.9.1" } }, "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="],
@@ -2973,6 +2979,10 @@
     "css-select/domutils/dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
 
     "file-loader/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "next/@playwright/test/playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "next/@playwright/test/playwright/playwright-core": ["playwright-core@1.61.0-alpha-1778188671000", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-nsw2Crz0uZS3IRHiEcOXUt+RaKB/Hna+GAD4oD6cPqCHfJfW77cJdgktC0jzp3Ndyv23EJI3bcWSqFIiqSNE5A=="],
 
     "null-loader/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 


### PR DESCRIPTION

Split the Playwright workflow into a 5-way matrix (chromium, firefox,
webkit, Mobile Chrome, Mobile Safari) so each browser project runs in
its own GitHub Actions job in parallel. Each job installs only the
required browser binary and runs `playwright test --project=...`,
shrinking wall-clock time significantly.

Local `bun test:e2e` continues to run all projects sequentially as
before since playwright.config.ts is unchanged at the matrix level.

Also fixes the artifact upload path to `@caravan-kidstec/web/playwright-report/`
and gives each shard a unique artifact name to avoid collisions.

Switches the Mobile Safari project's device to `iPhone 15`. The previous
`iPhone 16` does not exist in Playwright's device descriptors (latest is
iPhone 15), so the spread produced an empty `use` block and the project
silently fell back to chromium. That only worked previously because
`playwright install --with-deps` (no args) installed every browser; once
each matrix shard installs only the required browser, Mobile Safari
failed to find chromium. iPhone 15 has `defaultBrowserType: "webkit"`,
so it now correctly runs on WebKit.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
