### PR TITLE
fix(autofix.ci): apply automated fixes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -594,23 +594,23 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.0.7", "", { "dependencies": { "@emnapi/core": "^1.5.0", "@emnapi/runtime": "^1.5.0", "@tybys/wasm-util": "^0.10.1" } }, "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw=="],
 
-    "@next/env": ["@next/env@16.3.0-canary.36", "", {}, "sha512-J3bQDYrZTT9luixAhe7xv4MIJJBA+7RIL3+MTBw7Id5T8i3W/kKejU/4ZPLndgcQXDn5J85ZZ91vU4lwdZH33Q=="],
+    "@next/env": ["@next/env@16.3.0-canary.37", "", {}, "sha512-Bo89osKDM664fHQfd8wsRrEzf2uDD62AddPxsawNIOwsLG1qcf7j25Lb5fI26nr3ZMhK1HcEm0Hr3aDmXVlg7A=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.0-canary.36", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jcUwgZG5e+xNKI2DLllTbSnzrNy1WYsztE+dzHzfIf8NJkuWAtxt4aW7KB4HpT0dvTcrx7jy3UtRxFd0Unsy9Q=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.0-canary.37", "", { "os": "darwin", "cpu": "arm64" }, "sha512-eEBsQiD9aDEgGfSB3HIvcFZt9IawO3LvXyw2RtEW679i3CZ7GhvIzPS3AuItbVUsAbj85u34aF520QS+ofuNZg=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.3.0-canary.36", "", { "os": "darwin", "cpu": "x64" }, "sha512-U9/6XFul0HVoSJzR8dyu9wMpf6nmJ7diA/7xIBraB3UodAHvPIuyim+KGALvcFzH30/OMp1IbI5mqNu/Km4g6Q=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.3.0-canary.37", "", { "os": "darwin", "cpu": "x64" }, "sha512-WbF3ew+7crUlRD0tRClkKB0CBg9fXOLx7477ubEX6AowIhWfIeyy41DuDKDpaW1ym0vx3t5DP4ijsT50lpu48g=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.3.0-canary.36", "", { "os": "linux", "cpu": "arm64" }, "sha512-fTX1NbbP+dhqsDzx5LLHG4ESj26PrKpIe7fietpFcgjEAKN48RC1G0feBs/uvWpUiGV6kn9eiZIZ1uSaHQ/siA=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.3.0-canary.37", "", { "os": "linux", "cpu": "arm64" }, "sha512-q9kpIDnP00f5kNrmAaGUTjqvpJuTxjxGe/A+Ep7cEtXxfLvOYDhQYPJUR/TDjp+n5/7XgDx0uE8idu58GL2JZA=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.3.0-canary.36", "", { "os": "linux", "cpu": "arm64" }, "sha512-mkDmWxNJjg0zJACffvSu+hLf0gOKV7Cv6jpHCVjf0BdZXljmc2Jtnry6pNBB34dh6B0+E/tDjO/jKzOXMqU9Bg=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.3.0-canary.37", "", { "os": "linux", "cpu": "arm64" }, "sha512-/tW6rOJu+4b/vztrdsFuOG2tMGOmlWZlJ2o/M2iDTX5h8qVGqXWrfdx9gTwdrdRFveAHDwKPNxS26JwRUP2dFA=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.3.0-canary.36", "", { "os": "linux", "cpu": "x64" }, "sha512-zlw8ptIgmubt8bhLgqsdFRsHS+0beEwGCeHzFf+L5z4I+q0HdjB5tPIu0vsDtSPpQx4x0Ei6yMAntJ5ebM05HQ=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.3.0-canary.37", "", { "os": "linux", "cpu": "x64" }, "sha512-q9fG9pED96zVqk+obe2e+wVlPnTsFsKFG6qByaAivC0xhTxrD/ebFmqvEXctn5TlvQQeitfkVLuFecxcrUXc4w=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.3.0-canary.36", "", { "os": "linux", "cpu": "x64" }, "sha512-AeyU4n0Rkepmn7//+FyK6ViCcPFDfXJwDI6eLtg0Af+2QhRQHv+27sKIwqUmCJfHr0QGq/+jsvQxvXQuLAyvCw=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.3.0-canary.37", "", { "os": "linux", "cpu": "x64" }, "sha512-1Cy/TeH2B7Btp3zDD+vlz3p5m3sqcAgnCgTHezSkXKLzZ29/NcV5Yl/7DizrhTHegbBhDRl5vQgk+34jl1L05A=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.3.0-canary.36", "", { "os": "win32", "cpu": "arm64" }, "sha512-xJ7OLgMNDWCYQn1+76ewX7ycdHduDbV9GTgAYyurkXu+uPaUU/XW0mkKX9nbgmlzUK+Rn9HAza2oQY6w+vgR3g=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.3.0-canary.37", "", { "os": "win32", "cpu": "arm64" }, "sha512-SKFVfwLB0ZVinjUQdg9+tCQBBvzMYicwgNYihlYlTcjJg8cE8y5fq9ExoGM5Y0ovwPfbNfCJSQwBnbVQZILZIg=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.3.0-canary.36", "", { "os": "win32", "cpu": "x64" }, "sha512-O852mR72rl94dRUmzwT3+NDFbJEweLnwIh00VwJBZx/K+T7GjwsQHDr+rTZCs53w9EhB9HVKAfpUYzWhtZkmVA=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.3.0-canary.37", "", { "os": "win32", "cpu": "x64" }, "sha512-A2ftVpTYNLu8HOOcvB3HP+XLSsvBFKia3GvfnXzYzpUVkMy4HZo1e2OjDbG071dgCUczrrkOhvxzMYg9vkkolQ=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -618,7 +618,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@playwright/test": ["@playwright/test@1.61.0-alpha-2026-05-31", "", { "dependencies": { "playwright": "1.61.0-alpha-2026-05-31" }, "bin": { "playwright": "cli.js" } }, "sha512-5KHRiWd2m7ITtPmzZ7gyJNq60bwNhUiPFL03LHfKbktgAyvMVU/fgbWs+/wmCvPGvBzy9SzGEhdoKe9SPu69ZQ=="],
+    "@playwright/test": ["@playwright/test@1.61.0-alpha-2026-06-01", "", { "dependencies": { "playwright": "1.61.0-alpha-2026-06-01" }, "bin": { "playwright": "cli.js" } }, "sha512-eE/Hz7GLQeymq0axISbYtgpeBIltzcAbWFY8algIzSwPsyvTFt8mCh/mKJJl8zUjOFz2EtL8OVedDL8stKNS/Q=="],
 
     "@pnpm/config.env-replace": ["@pnpm/config.env-replace@1.1.0", "", {}, "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="],
 
@@ -1800,7 +1800,7 @@
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
-    "next": ["next@16.3.0-canary.36", "", { "dependencies": { "@next/env": "16.3.0-canary.36", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.5.10", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.0-canary.36", "@next/swc-darwin-x64": "16.3.0-canary.36", "@next/swc-linux-arm64-gnu": "16.3.0-canary.36", "@next/swc-linux-arm64-musl": "16.3.0-canary.36", "@next/swc-linux-x64-gnu": "16.3.0-canary.36", "@next/swc-linux-x64-musl": "16.3.0-canary.36", "@next/swc-win32-arm64-msvc": "16.3.0-canary.36", "@next/swc-win32-x64-msvc": "16.3.0-canary.36", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-0/2B93GLozKLwQceJvwoZsG1HOSSbLwXMM5lZd31QTm6pyUAR4jvn2bqN+oJ6ZEp4ht/qU4Inj6fX+vR430J+A=="],
+    "next": ["next@16.3.0-canary.37", "", { "dependencies": { "@next/env": "16.3.0-canary.37", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.5.10", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.0-canary.37", "@next/swc-darwin-x64": "16.3.0-canary.37", "@next/swc-linux-arm64-gnu": "16.3.0-canary.37", "@next/swc-linux-arm64-musl": "16.3.0-canary.37", "@next/swc-linux-x64-gnu": "16.3.0-canary.37", "@next/swc-linux-x64-musl": "16.3.0-canary.37", "@next/swc-win32-arm64-msvc": "16.3.0-canary.37", "@next/swc-win32-x64-msvc": "16.3.0-canary.37", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-eQm/MtfH3ZmyBkp6I3YmLFF+6RZmzHWmgKWjpbUWHSfsR9fFpmvwOSjfD/BJ550vw673HvQLyP2VYLDqIVMwLw=="],
 
     "next-view-transitions": ["next-view-transitions@0.3.5", "", { "peerDependencies": { "next": ">=14.0.0", "react": ">=18.2.0 || ^19.0.0", "react-dom": ">=18.2.0 || ^19.0.0" } }, "sha512-yP8OPNydLmKpmE94hLurLGEzPsUy1uyl9iSv8oxaC2JwhSXTD86SVwk1NMMQT7Ado4kMENDJ7fNBIXHy3GU/Lg=="],
 
@@ -1900,9 +1900,9 @@
 
     "pkg-dir": ["pkg-dir@7.0.0", "", { "dependencies": { "find-up": "^6.3.0" } }, "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA=="],
 
-    "playwright": ["playwright@1.61.0-alpha-2026-05-31", "", { "dependencies": { "playwright-core": "1.61.0-alpha-2026-05-31" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-UJ8qSxw//fVA1iw9uxfvD09ZAaE4qUlLoJBoxcTKdFd8YEfUYb4KHYTa0excPIRMWiZQubfNMPu5R/AO4cddeg=="],
+    "playwright": ["playwright@1.61.0-alpha-2026-06-01", "", { "dependencies": { "playwright-core": "1.61.0-alpha-2026-06-01" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-tBlatMRW9V7IZl50faQpIkHs7qz7U5oxw2raeDRlc1uMd91hVpsE6XIp2fY1Z6hVIYkQeCeO3I5NP9J5vKbSvQ=="],
 
-    "playwright-core": ["playwright-core@1.61.0-alpha-2026-05-31", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-+pLPMq3KuOQeAFlgVwj/YW8g4yCc3DABxadtP9Lub04T0Ne7XdmP2thWcvDNkFiXBly1Q9eaynty63uBjT59Vw=="],
+    "playwright-core": ["playwright-core@1.61.0-alpha-2026-06-01", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-QP5JCCuFJ+Yoh3dbXqSHVqV76VblK1T+dFIDs9RI9iRCEU/hlOpvt9cKJJXivVo7i+9XJgYfs2ERzvCaNZ0Y/g=="],
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
@@ -2756,6 +2756,8 @@
 
     "next/postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
+    "next-view-transitions/next": ["next@16.3.0-canary.36", "", { "dependencies": { "@next/env": "16.3.0-canary.36", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.5.10", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.0-canary.36", "@next/swc-darwin-x64": "16.3.0-canary.36", "@next/swc-linux-arm64-gnu": "16.3.0-canary.36", "@next/swc-linux-arm64-musl": "16.3.0-canary.36", "@next/swc-linux-x64-gnu": "16.3.0-canary.36", "@next/swc-linux-x64-musl": "16.3.0-canary.36", "@next/swc-win32-arm64-msvc": "16.3.0-canary.36", "@next/swc-win32-x64-msvc": "16.3.0-canary.36", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-0/2B93GLozKLwQceJvwoZsG1HOSSbLwXMM5lZd31QTm6pyUAR4jvn2bqN+oJ6ZEp4ht/qU4Inj6fX+vR430J+A=="],
+
     "null-loader/schema-utils": ["schema-utils@3.3.0", "", { "dependencies": { "@types/json-schema": "^7.0.8", "ajv": "^6.12.5", "ajv-keywords": "^3.5.2" } }, "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg=="],
 
     "package-json/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
@@ -2950,6 +2952,28 @@
 
     "mdast-util-gfm-autolink-literal/micromark-util-character/micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
 
+    "next-view-transitions/next/@next/env": ["@next/env@16.3.0-canary.36", "", {}, "sha512-J3bQDYrZTT9luixAhe7xv4MIJJBA+7RIL3+MTBw7Id5T8i3W/kKejU/4ZPLndgcQXDn5J85ZZ91vU4lwdZH33Q=="],
+
+    "next-view-transitions/next/@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.0-canary.36", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jcUwgZG5e+xNKI2DLllTbSnzrNy1WYsztE+dzHzfIf8NJkuWAtxt4aW7KB4HpT0dvTcrx7jy3UtRxFd0Unsy9Q=="],
+
+    "next-view-transitions/next/@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.3.0-canary.36", "", { "os": "darwin", "cpu": "x64" }, "sha512-U9/6XFul0HVoSJzR8dyu9wMpf6nmJ7diA/7xIBraB3UodAHvPIuyim+KGALvcFzH30/OMp1IbI5mqNu/Km4g6Q=="],
+
+    "next-view-transitions/next/@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.3.0-canary.36", "", { "os": "linux", "cpu": "arm64" }, "sha512-fTX1NbbP+dhqsDzx5LLHG4ESj26PrKpIe7fietpFcgjEAKN48RC1G0feBs/uvWpUiGV6kn9eiZIZ1uSaHQ/siA=="],
+
+    "next-view-transitions/next/@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.3.0-canary.36", "", { "os": "linux", "cpu": "arm64" }, "sha512-mkDmWxNJjg0zJACffvSu+hLf0gOKV7Cv6jpHCVjf0BdZXljmc2Jtnry6pNBB34dh6B0+E/tDjO/jKzOXMqU9Bg=="],
+
+    "next-view-transitions/next/@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.3.0-canary.36", "", { "os": "linux", "cpu": "x64" }, "sha512-zlw8ptIgmubt8bhLgqsdFRsHS+0beEwGCeHzFf+L5z4I+q0HdjB5tPIu0vsDtSPpQx4x0Ei6yMAntJ5ebM05HQ=="],
+
+    "next-view-transitions/next/@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.3.0-canary.36", "", { "os": "linux", "cpu": "x64" }, "sha512-AeyU4n0Rkepmn7//+FyK6ViCcPFDfXJwDI6eLtg0Af+2QhRQHv+27sKIwqUmCJfHr0QGq/+jsvQxvXQuLAyvCw=="],
+
+    "next-view-transitions/next/@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.3.0-canary.36", "", { "os": "win32", "cpu": "arm64" }, "sha512-xJ7OLgMNDWCYQn1+76ewX7ycdHduDbV9GTgAYyurkXu+uPaUU/XW0mkKX9nbgmlzUK+Rn9HAza2oQY6w+vgR3g=="],
+
+    "next-view-transitions/next/@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.3.0-canary.36", "", { "os": "win32", "cpu": "x64" }, "sha512-O852mR72rl94dRUmzwT3+NDFbJEweLnwIh00VwJBZx/K+T7GjwsQHDr+rTZCs53w9EhB9HVKAfpUYzWhtZkmVA=="],
+
+    "next-view-transitions/next/@playwright/test": ["@playwright/test@1.61.0-alpha-2026-05-31", "", { "dependencies": { "playwright": "1.61.0-alpha-2026-05-31" }, "bin": { "playwright": "cli.js" } }, "sha512-5KHRiWd2m7ITtPmzZ7gyJNq60bwNhUiPFL03LHfKbktgAyvMVU/fgbWs+/wmCvPGvBzy9SzGEhdoKe9SPu69ZQ=="],
+
+    "next-view-transitions/next/postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
+
     "next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "null-loader/schema-utils/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
@@ -2996,10 +3020,18 @@
 
     "file-loader/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
+    "next-view-transitions/next/@playwright/test/playwright": ["playwright@1.61.0-alpha-2026-05-31", "", { "dependencies": { "playwright-core": "1.61.0-alpha-2026-05-31" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-UJ8qSxw//fVA1iw9uxfvD09ZAaE4qUlLoJBoxcTKdFd8YEfUYb4KHYTa0excPIRMWiZQubfNMPu5R/AO4cddeg=="],
+
+    "next-view-transitions/next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
     "null-loader/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "renderkid/htmlparser2/domutils/dom-serializer": ["dom-serializer@1.4.1", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.0", "entities": "^2.0.0" } }, "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag=="],
 
     "url-loader/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "next-view-transitions/next/@playwright/test/playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "next-view-transitions/next/@playwright/test/playwright/playwright-core": ["playwright-core@1.61.0-alpha-2026-05-31", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-+pLPMq3KuOQeAFlgVwj/YW8g4yCc3DABxadtP9Lub04T0Ne7XdmP2thWcvDNkFiXBly1Q9eaynty63uBjT59Vw=="],
   }
 }


### PR DESCRIPTION
## Summary by Sourcery

雑務:
- 現在の依存関係の状態を反映するために、autofix ツールを使用して `bun.lock` を再生成しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Regenerate bun.lock via autofix tooling to reflect the current dependency state.

</details>